### PR TITLE
API for creating special plots for nodes

### DIFF
--- a/src/gui/GUI.jl
+++ b/src/gui/GUI.jl
@@ -439,27 +439,27 @@ function arguments(::Type{Neuroblox.CorticalBlox}) #TODO: add correct settings f
 end
 
 function plotdetail(::Type{Neuroblox.CorticalBlox})
-  OrderedDict(:mean => "V", :detail => ["V"])
+  OrderedDict(:mean => "V", :detail => ["V"], :plots =>["raster","stack"])
 end
 
-function arguments(::Type{Neuroblox.BandPassFilterBlox})
-  OrderedDict(
-    :lb => NCAD(10, NUMBER, 0, 500,[],true),
-    :ub => NCAD(10, NUMBER, 0, 500,[],true),
-    :fs => NCAD(1000, NUMBER, 1, 10000,[],true),
-    :order => NCAD(4, INTEGER, 1, 2000,[],true)
-  )
-end
+# function arguments(::Type{Neuroblox.BandPassFilterBlox})
+#   OrderedDict(
+#     :lb => NCAD(10, NUMBER, 0, 500,[],true),
+#     :ub => NCAD(10, NUMBER, 0, 500,[],true),
+#     :fs => NCAD(1000, NUMBER, 1, 10000,[],true),
+#     :order => NCAD(4, INTEGER, 1, 2000,[],true)
+#   )
+# end
 
-function arguments(::Type{Neuroblox.PowerSpectrumBlox})
-  OrderedDict(
-    :fs => NCAD(1000, NUMBER, 1, 10000,[],true),
-  )
-end
+# #function arguments(::Type{Neuroblox.PowerSpectrumBlox})
+#   OrderedDict(
+#     :fs => NCAD(1000, NUMBER, 1, 10000,[],true),
+#   )
+# end
 
-function arguments(::Type{Neuroblox.PhaseAngleBlox})
-  OrderedDict(
-  )
-end
+# function arguments(::Type{Neuroblox.PhaseAngleBlox})
+#   OrderedDict(
+#   )
+# end
 
 end

--- a/src/gui/GUI.jl
+++ b/src/gui/GUI.jl
@@ -56,6 +56,10 @@ function param_order(::Type{T}) where T
   return [k for k in keys(arguments(T))]
 end
 
+function plotdetail(::Type{T}) where T
+  return OrderedDict()
+end
+
 # methods
 
 const NUMBER = "number"

--- a/src/gui/GUI.jl
+++ b/src/gui/GUI.jl
@@ -290,7 +290,7 @@ function arguments(::Type{Neuroblox.Thalamus})
 end
 
 function plotdetail(::Type{Neuroblox.Thalamus})
-  OrderedDict(:mean => "V", :detail => ["V"])
+  OrderedDict(:mean => "V", :detail => ["V"], :plots =>["raster","stack"])
 end
 
 function arguments(::Type{Neuroblox.Striatum})
@@ -303,7 +303,7 @@ function arguments(::Type{Neuroblox.Striatum})
 end
 
 function plotdetail(::Type{Neuroblox.Striatum})
-  OrderedDict(:mean => "V", :detail => ["V"])
+  OrderedDict(:mean => "V", :detail => ["V"], :plots =>["raster","stack"])
 end
 
 function arguments(::Type{Neuroblox.GPe})
@@ -316,7 +316,7 @@ function arguments(::Type{Neuroblox.GPe})
 end
 
 function plotdetail(::Type{Neuroblox.GPe})
-  OrderedDict(:mean => "V", :detail => ["V"])
+  OrderedDict(:mean => "V", :detail => ["V"], :plots =>["raster","stack"])
 end
 
 function arguments(::Type{Neuroblox.GPi})
@@ -329,7 +329,7 @@ function arguments(::Type{Neuroblox.GPi})
 end
 
 function plotdetail(::Type{Neuroblox.GPi})
-  OrderedDict(:mean => "V", :detail => ["V"])
+  OrderedDict(:mean => "V", :detail => ["V"], :plots =>["raster","stack"])
 end
 
 function arguments(::Type{Neuroblox.STN})
@@ -342,7 +342,7 @@ function arguments(::Type{Neuroblox.STN})
 end
 
 function plotdetail(::Type{Neuroblox.STN})
-  OrderedDict(:mean => "V", :detail => ["V"])
+  OrderedDict(:mean => "V", :detail => ["V"], :plots =>["raster","stack"])
 end
 
 function arguments(::Type{Neuroblox.SNc})


### PR DESCRIPTION
When a node is selected then this API makes available special plots when appropriate.  For example, a cortical blox will allow a raster plot, and a stack plot.