### PR TITLE
Improve `show` for `Connector` objects

### DIFF
--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -42,7 +42,7 @@ using SciMLBase: SciMLBase, AbstractSolution, solve, remake
 using ModelingToolkit: get_namespace, get_systems, isparameter,
                     renamespace, namespace_equation, namespace_parameters, namespace_expr,
                     AbstractODESystem, VariableTunable, getp
-import ModelingToolkit: inputs, nameof, outputs, getdescription
+import ModelingToolkit: equations, inputs, nameof, getdescription
 
 using Symbolics: @register_symbolic, getdefaultval, get_variables
 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -84,11 +84,11 @@ end
 generate_discrete_callbacks(blox, ::Connector; t_block = missing) = []
 
 function generate_discrete_callbacks(blox::Union{LIFExciNeuron, LIFInhNeuron}, bc::Connector; t_block = missing)
-    spike_affects = get_spike_affects(bc)
+    sa = spike_affects(bc)
     name_blox = namespaced_nameof(blox)
     sys = get_namespaced_sys(blox)
 
-    states_affect, params_affect = get(spike_affects, name_blox, (Num[], Num[]))
+    states_affect, params_affect = get(sa, name_blox, (Num[], Num[]))
 
     # HACK : MTK will complain if the parameter vector passed to a functional affect
     # contains non-unique parameters. Here we sometimes need to pass duplicate parameters that 
@@ -136,27 +136,28 @@ function generate_discrete_callbacks(blox::HHNeuronExciBlox, ::Connector; t_bloc
     end
 end
 
-function generate_discrete_callbacks(bc::Connector; t_block = missing)
-    eqs_params = get_equations_with_parameter_lhs(bc)
+function generate_discrete_callbacks(bc::Connector, eqs::AbstractVector{<:Equation}; t_block = missing)
+    eqs_params = get_equations_with_parameter_lhs(eqs)
+    dc = discrete_callbacks(bc)
 
     if !ismissing(t_block) && !isempty(eqs_params)
         cb_params = (t_block - sqrt(eps(float(t_block)))) => eqs_params
-        return vcat(cb_params, bc.discrete_callbacks)
+        return vcat(cb_params, dc)
     else
-        return bc.discrete_callbacks
+        return dc
     end 
 end
 
-function generate_discrete_callbacks(g::MetaDiGraph, bc::Connector; t_block = missing)
+function generate_discrete_callbacks(g::MetaDiGraph, bc::Connector, eqs::AbstractVector{<:Equation}; t_block = missing)
     bloxs = flatten_graph(g)
 
     cbs = mapreduce(vcat, bloxs) do blox
         generate_discrete_callbacks(blox, bc; t_block)
     end
     
-    cbs_params = generate_discrete_callbacks(bc; t_block)
+    cbs_connections = generate_discrete_callbacks(bc, eqs; t_block)
 
-    return vcat(cbs, cbs_params)
+    return vcat(cbs, cbs_connections)
 end
 
 
@@ -197,11 +198,12 @@ function system_from_graph(g::MetaDiGraph, bc::Connector, p::Vector{Num}=Num[]; 
     bloxs = get_bloxs(g)
     blox_syss = get_system.(bloxs)
 
-    accumulate_equations!(bc, bloxs)
+    eqs = equations(bc)
+    accumulate_equations!(eqs, bloxs)
 
-    connection_eqs = get_equations_with_state_lhs(bc)
+    connection_eqs = get_equations_with_state_lhs(eqs)
 
-    discrete_cbs = identity.(generate_discrete_callbacks(g, bc; t_block))
+    discrete_cbs = identity.(generate_discrete_callbacks(g, bc, eqs; t_block))
 
     sys = compose(System(connection_eqs, t, [], vcat(params(bc), p); name, discrete_events = discrete_cbs), blox_syss)
     if simplify

--- a/src/adjacency.jl
+++ b/src/adjacency.jl
@@ -8,15 +8,16 @@ function AdjacencyMatrix(names::AbstractVector)
 end
 
 function AdjacencyMatrix(C::Connector)
-    weights = C.weight
-    srcs = C.source
-    dests = C.destination
+    w = weights(C)
+    srcs = sources(C)
+    dests = destinations(C)
     names = unique(vcat(srcs, dests))
+   
     sort!(names)
 
     ADJ = AdjacencyMatrix(spzeros(length(names), length(names)), names)
     for i in eachindex(srcs)
-        add_adjacency_edge!(ADJ, srcs[i], dests[i], weights[i])
+        add_adjacency_edge!(ADJ, srcs[i], dests[i], w[i])
     end
 
     return ADJ

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -163,31 +163,10 @@ function get_input_equations(blox::Union{AbstractBlox, ObserverBlox})
     end
 end
 
-get_connector(blox::Union{CompositeBlox, Agent}) = blox.connector
-get_connector(blox) = Connector(namespaced_nameof(blox), namespaced_nameof(blox))
-
-get_input_equations(bc::Connector) = bc.equation
 get_input_equations(blox) = []
 
-get_weight_parameters(bc::Connector) = bc.weights
-get_weight_parameters(blox::Union{CompositeBlox, AbstractComponent}) = (get_weight_parameters ∘ get_connector)(blox)
-get_weight_parameters(blox) = Num[]
-
-get_delay_parameters(bc::Connector) = bc.delays
-get_delay_parameters(blox::Union{CompositeBlox, AbstractComponent}) = (get_delay_parameters ∘ get_connector)(blox)
-get_delay_parameters(blox) = Num[]
-
-get_discrete_callbacks(bc::Connector) = bc.discrete_callbacks
-get_discrete_callbacks(blox::Union{CompositeBlox, AbstractComponent}) = (get_discrete_callbacks ∘ get_connector)(blox)
-get_discrete_callbacks(blox) = []
-
-get_spike_affects(bc::Connector) = bc.spike_affects
-get_spike_affects(blox::Union{CompositeBlox, AbstractComponent}) = (get_spike_affects ∘ get_connector)(blox)
-get_spike_affects(blox) = Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}()
-
-get_weight_learning_rules(bc::Connector) = bc.learning_rules
-get_weight_learning_rules(blox::Union{CompositeBlox, AbstractComponent}) = (get_weight_learning_rules ∘ get_connector)(blox)
-get_weight_learning_rules(blox) = Dict{Num, AbstractLearningRule}()
+get_connector(blox::Union{CompositeBlox, Agent}) = blox.connector
+get_connector(blox) = Connector(namespaced_nameof(blox), namespaced_nameof(blox))
 
 function get_weight(kwargs, name_blox1, name_blox2)
     get(kwargs, :weight) do

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -389,6 +389,10 @@ end
 to_vector(v::AbstractVector) = v
 to_vector(v) = [v]
 
+to_double_vector(v::AbstractVector{<:AbstractVector}) = v
+to_double_vector(v::AbstractVector) = [v]
+to_double_vector(v) = [[v]]
+
 nanmean(x) = mean(filter(!isnan,x))
 
 function replace_refractory!(V, blox::Union{LIFExciNeuron, LIFInhNeuron}, sol::SciMLBase.AbstractSolution)

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -86,11 +86,11 @@ function Base.show(io::IO, ::MIME"text/plain", c::Connector)
     end 
 end
 
-function accumulate_equations!(C::Connector, bloxs)
+function accumulate_equations!(eqs::AbstractVector{<:Equation}, bloxs)
     init_eqs = mapreduce(get_input_equations, vcat, bloxs)
-    accumulate_equations!(C.equation, init_eqs)
+    accumulate_equations!(eqs, init_eqs)
 
-    return C
+    return eqs
 end
 
 function accumulate_equations!(eqs1::Vector{<:Equation}, eqs2::Vector{<:Equation})
@@ -108,6 +108,8 @@ function accumulate_equations!(eqs1::Vector{<:Equation}, eqs2::Vector{<:Equation
     return eqs1
 end
 
+ModelingToolkit.equations(c::Connector) = reduce(accumulate_equations!, c.equation)
+
 function tuple_append!(t1::Tuple, t2::Tuple)
     append!(first(t1), first(t2))
     append!(last(t1), last(t2))
@@ -115,9 +117,23 @@ function tuple_append!(t1::Tuple, t2::Tuple)
     return t1
 end
 
-get_equations_with_parameter_lhs(bc) = filter(eq -> isparameter(eq.lhs), bc.equation)
+discrete_callbacks(c::Connector) = reduce(append!, c.discrete_callbacks)
 
-get_equations_with_state_lhs(bc) = filter(eq -> !isparameter(eq.lhs), bc.equation)
+sources(c::Connector) = reduce(append!, c.source)
+
+destinations(c::Connector) = reduce(append!, c.destination)
+
+weights(c::Connector) = reduce(append!, c.weight)
+
+delays(c::Connector) = reduce(append!, c.delay)
+
+spike_affects(c::Connector) = c.spike_affects
+
+learning_rules(c::Connector) = c.learning_rule
+
+get_equations_with_parameter_lhs(eqs::AbstractVector{<:Equation}) = filter(eq -> isparameter(eq.lhs), eqs)
+
+get_equations_with_state_lhs(eqs::AbstractVector{<:Equation}) = filter(eq -> !isparameter(eq.lhs), eqs)
 
 function generate_weight_param(blox_out, blox_in; kwargs...)
     name_out = namespaced_nameof(blox_out)
@@ -153,21 +169,21 @@ end
     Helper to merge delay and weight into a single vector
 """
 function params(bc::Connector)
-    weight = []
-    for w in bc.weight
-        append!(weight, Symbolics.get_variables(w))
+    wt = map(weights(bc)) do w
+        Symbolics.get_variables(w)
     end
-    if isempty(weight)
-        return vcat(weight, bc.delay)
+
+    if isempty(wt)
+        return vcat(wt, delays(bc))
     else
-        return vcat(reduce(vcat, weight), bc.delay)
+        return vcat(reduce(vcat, wt), delays(bc))
     end
 end
 
 function Base.merge!(c1::Connector, c2::Connector)
     append!(c1.source, c2.source)
     append!(c1.destination, c2.destination)
-    accumulate_equations!(c1.equation, c2.equation)
+    append!(c1.equation, c2.equation)
     append!(c1.weight, c2.weight)
     append!(c1.delay, c2.delay)
     append!(c1.discrete_callbacks, c2.discrete_callbacks)

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -42,32 +42,48 @@ end
 
 connection_rule(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...)
 
-connection_equation(blox_src, blox_dest; kwargs...) = get_single_element(Connector(blox_src, blox_dest; kwargs...).equation)
+Base.show(io::IO, c::Connector) = print(io, "$(c.source) => $(c.destination) with ", c.equation)
 
-get_single_element(v::Union{AbstractVector, Dict}) = length(v) == 1 ? only(v) : v
+function string_to_show(v, title)
+    s = string.(v)
 
-Base.show(io::IO, c::Connector) = print(io, "$(c.source) connects to $(c.destination) with ", c.equation)
+    return string("\t $(title): ", "[", join(s, " , "), "]")
+end
+
+function string_to_show(d::Dict, title)
+    s = [string(k, " => ", v) for (k,v) in d]
+
+    return string("\t $(title): ", "[", join(s, " , "), "]")
+end
 
 function Base.show(io::IO, ::MIME"text/plain", c::Connector)
+    N_conns = length(c.source)
+    
+    for i in Base.OneTo(N_conns)
+        println("Connection $(c.source[i]) => $(c.destination[i])")
 
-    lines = ["Connection from $(get_single_element(c.source)) to $(get_single_element(c.destination))"]
+        !isempty(c.equation[i]) && println(string_to_show(c.equation[i], "Equation"))
+        !isempty(c.weight[i]) && println(string_to_show(c.weight[i], "Weight"))
+        !isempty(c.delay[i]) && println(string_to_show(c.delay[i], "Delay"))
 
-    !isempty(c.equation) && push!(lines, "Equation : $(get_single_element(c.equation))")
-    !isempty(c.weight) && push!(lines, "Weight : $(get_single_element(c.weight))")
-    !isempty(c.delay) && push!(lines, "Delay : $(get_single_element(c.delay))")
-    !isempty(c.discrete_callbacks) && push!(lines, "Preset time events : $(get_single_element(c.discrete_callbacks))")
-
-    if !isempty(c.spike_affects)
-        push!(lines, "$(get_single_element(c.source)) spikes affect :")
-        for (k, v) in c.spike_affects
-            var, val = get_single_element.(v)
-            push!(lines, "\t $(var) += $(val)")
+        d = Dict()
+        for w in c.weight[i]    
+            if haskey(c.learning_rule, w)
+                d[w] = c.learning_rule[w]
+            end
         end
-    end
+        !isempty(d) && println(string_to_show(d, "Plasticity model"))
 
-    !isempty(c.learning_rule) && push!(lines, "Plasticity rule : $(get_single_element(c.learning_rule))")
-
-    print(io, join(lines, " \n "))
+        for s in c.source[i]
+            if haskey(c.spike_affects, s)
+                println("\t $(s) spikes affect :")
+                vars, vals = c.spike_affects[s]
+                for (var, val) in zip(vars, vals)
+                    println("\t \t $(var) += $(val)")
+                end
+            end
+        end
+    end 
 end
 
 function accumulate_equations!(C::Connector, bloxs)

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -1,22 +1,22 @@
 struct Connector
-    source::Vector{Symbol}
-    destination::Vector{Symbol}
-    equation::Vector{Equation}
-    weight::Vector{Num}
-    delay::Vector{Num}
+    source::Vector{Vector{Symbol}}
+    destination::Vector{Vector{Symbol}}
+    equation::Vector{Vector{Equation}}
+    weight::Vector{Vector{Num}}
+    delay::Vector{Vector{Num}}
     discrete_callbacks
     spike_affects::Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}
     learning_rule::Dict{Num, AbstractLearningRule}
 end
 
 function Connector(
-    src::Symbol, 
-    dest::Symbol; 
+    src::Union{Symbol, Vector{Symbol}}, 
+    dest::Union{Symbol, Vector{Symbol}}; 
     equation=Equation[], 
     weight=Num[], 
     delay=Num[], 
     discrete_callbacks=[], 
-    spike_affects=Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}(), 
+    spike_affects=Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}(),
     learning_rule=Dict{Num, AbstractLearningRule}()
     )
 
@@ -25,19 +25,19 @@ function Connector(
     learning_rule = U <: NoLearningRule ? Dict{Num, NoLearningRule}() : learning_rule
 
     Connector(
-        [src], 
-        [dest], 
-        to_vector(equation), 
-        to_vector(weight), 
-        to_vector(delay), 
-        to_vector(discrete_callbacks), 
+        to_double_vector(src), 
+        to_double_vector(dest), 
+        to_double_vector(equation), 
+        to_double_vector(weight), 
+        to_double_vector(delay), 
+        to_double_vector(discrete_callbacks), 
         spike_affects, 
         learning_rule
     )
 end
 
 function Base.isempty(conn::Connector)
-    return isempty(conn.equation) && isempty(conn.weight) && isempty(conn.delay) && isempty(conn.discrete_callbacks) && isempty(conn.spike_affects) && isempty(conn.learning_rule)
+    return all(isempty.(conn.equation)) && all(isempty.(conn.weight)) && all(isempty.(conn.delay)) && all(isempty.(conn.discrete_callbacks)) && isempty(conn.spike_affects) && isempty(conn.learning_rule)
 end
 
 connection_rule(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...)
@@ -921,14 +921,14 @@ function Connector(
                     (1 + sys_dest.Mg * exp(-0.062 * sys_dest.V) / 3.57)
     
     # Compare the unique namespaced names of both systems
-    spike_affects = if nameof(sys_src) == nameof(sys_dest)
+    sa = if nameof(sys_src) == nameof(sys_dest)
         # x is the rise variable for NMDA synapses and it only applies to self-recurrent connections
-        Dict(nameof(sys_src) => ([sys_dest.S_AMPA, sys_dest.x], [w, w]))
+        nameof(sys_src) => ([sys_dest.S_AMPA, sys_dest.x], [w, w])
     else
-        Dict(nameof(sys_src) => ([sys_dest.S_AMPA], [w]))
+        nameof(sys_src) => ([sys_dest.S_AMPA], [w])
     end
 
-    return Connector(nameof(sys_src), nameof(sys_dest); equation = eq, weight = [w], spike_affects = spike_affects)
+    return Connector(nameof(sys_src), nameof(sys_dest); equation = eq, weight = [w], spike_affects = Dict(sa))
 end
 
 function Connector(
@@ -941,9 +941,9 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    spike_affects = Dict(nameof(sys_src) => ([sys_dest.S_GABA], [w]))
+    sa = nameof(sys_src) => ([sys_dest.S_GABA], [w])
 
-    return Connector(nameof(sys_src), nameof(sys_dest); weight = w, spike_affects = spike_affects)
+    return Connector(nameof(sys_src), nameof(sys_dest); weight = w, spike_affects = Dict(sa))
 end
 
 function Connector(

--- a/src/blox/reinforcement_learning.jl
+++ b/src/blox/reinforcement_learning.jl
@@ -202,9 +202,9 @@ mutable struct Agent{S,P,A,LR,C}
         prob = ODEProblem(sys, u0, (0.,1.), p)
         
         policy = action_selection_from_graph(g)
-        learning_rules =  narrowtype(bc.learning_rule)  
+        lr =  narrowtype(learning_rules(bc))  
 
-        new{typeof(sys), typeof(prob), typeof(policy), typeof(learning_rules), typeof(bc)}(sys, prob, policy, learning_rules, bc)
+        new{typeof(sys), typeof(prob), typeof(policy), typeof(lr), typeof(bc)}(sys, prob, policy, lr, bc)
     end
 end
 


### PR DESCRIPTION
Changes how `Connector` objects are shown for user friendliness. 

The `Connector` fields are now `Vector{Vector{...}}` to keep track of the fields of individual connections while being also able to reduce over them for the final system. `spike_affects` and `learning_rule` are still `Dict`s since their keys are other `Connector` fields, so accessing connection-specific affects and plasticity rules is easy. 