### PR TITLE
Generic `Connector` dispatch

### DIFF
--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -223,6 +223,7 @@ function __init__()
 end
 
 
+export Neuron
 export JansenRitSPM12, next_generation, qif_neuron, if_neuron, hh_neuron_excitatory, 
     hh_neuron_inhibitory, van_der_pol, Generic2dOscillator
 export HHNeuronExciBlox, HHNeuronInhibBlox, IFNeuron, LIFNeuron, QIFNeuron, IzhikevichNeuron, LIFExciNeuron, LIFInhNeuron,
@@ -243,7 +244,7 @@ export powerspectrum, complexwavelet, bandpassfilter, hilberttransform, phaseang
 export learningrate, ControlError
 export vecparam, csd_Q, setup_sDCM, run_sDCM_iteration!, defaultprior
 export simulate, random_initials
-export system_from_graph, graph_delays
+export system_from_graph, system, graph_delays
 export create_adjacency_edges!, adjmatrixfromdigraph
 export get_namespaced_sys, nameof
 export run_experiment!, run_trial!
@@ -256,5 +257,5 @@ export meanfield, meanfield!, rasterplot, rasterplot!, stackplot, stackplot!, fr
 export powerspectrumplot, powerspectrumplot!, welch_pgram, periodogram, hanning, hamming
 export detect_spikes, mean_firing_rate, firing_rate
 export voltage_timeseries, meanfield_timeseries, state_timeseries, get_neurons, get_exci_neurons, get_inh_neurons, get_neuron_color
-export AdjacencyMatrix, Connector, connection_rule, connection_equation
+export AdjacencyMatrix, Connector, connection_rule, connection_equations, connection_spike_affects, connection_learning_rules, connection_callbacks
 end

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -68,6 +68,7 @@ abstract type StimulusBlox <: AbstractBlox end
 abstract type ObserverBlox end # not AbstractBlox since it should not show up in the GUI
 abstract type AbstractPINGNeuron <: AbstractNeuronBlox end
 
+const Neuron = AbstractNeuronBlox
 
 # we define these in neural_mass.jl
 # abstract type HarmonicOscillatorBlox <: NeuralMassBlox end

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -8,9 +8,8 @@ using OhMyThreads: tmapreduce
 
 using Reexport
 @reexport using ModelingToolkit
-const t = ModelingToolkit.t_nounits
-const D = ModelingToolkit.D_nounits
-export t, D
+@reexport using ModelingToolkit: ModelingToolkit.t_nounits as t, ModelingToolkit.D_nounits as D
+
 @reexport using ModelingToolkitStandardLibrary.Blocks
 @reexport import Graphs: add_edge!
 @reexport using MetaGraphs: MetaDiGraph

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -81,37 +81,91 @@ function graph_delays(g::MetaDiGraph)
     return conn.delay
 end
 
-generate_discrete_callbacks(blox, ::Connector; t_block = missing) = []
-
-function generate_discrete_callbacks(blox::Union{LIFExciNeuron, LIFInhNeuron}, bc::Connector; t_block = missing)
-    sa = spike_affects(bc)
-    name_blox = namespaced_nameof(blox)
-    sys = get_namespaced_sys(blox)
-
-    states_affect, params_affect = get(sa, name_blox, (Num[], Num[]))
-
+function make_unique_param_pairs(params)
     # HACK : MTK will complain if the parameter vector passed to a functional affect
     # contains non-unique parameters. Here we sometimes need to pass duplicate parameters that 
     # affect states in the loop in LIF_spike_affect! .
     # Passing parameters with Symbol aliases bypasses this issue and allows for duplicates. 
-    affect_pairs = if unique(params_affect) == length(params_affect)
-        [p => Symbol(p) for p in params_affect]
+    param_pairs = if unique(params) == length(params)
+        [p => Symbol(p) for p in params]
     else
-        map(params_affect) do p
-            if count(pi -> Symbol(pi) == Symbol(p), params_affect) > 1
+        map(params) do p
+            if count(pi -> Symbol(pi) == Symbol(p), params) > 1
                 p => Symbol(p, "_$(rand(1:1000))")
             else
                 p => Symbol(p)
             end
         end
     end
+
+    return param_pairs
+end
+
+function generic_spike_affect!(integ, u, p, ctx)
+    N = length(u)
+    for i in Base.OneTo(N)
+        integ.u[u[i]] += integ.p[p[i]]
+    end
+end
+
+function LIF_spike_affect!(integ, u, p, ctx)
+    integ.u[u[1]] = integ.p[p[1]]
+
+    t_refract_end = integ.t + integ.p[p[2]]
+    integ.p[p[3]] = t_refract_end
+
+    integ.p[p[4]] = 1
+
+    SciMLBase.add_tstop!(integ, t_refract_end)
+    
+    c = 1
+    for i in eachindex(u)[2:end]
+        integ.u[u[i]] += integ.p[p[c + 4]]
+        c += 1
+    end
+end
+
+function generate_discrete_callbacks(blox::AbstractNeuronBlox, bc::Connector; t_block = missing)
+    sa = spike_affects(bc)
+    name_blox = namespaced_nameof(blox)
+    sys = get_namespaced_sys(blox)
+
+    states_affect = get_states_spikes_affect(sa, name_blox)
+    params_affect = get_params_spikes_affect(sa, name_blox)
+    
+    if isempty(states_affect) && isempty(params_affect)
+        return []
+    else
+        param_pairs = make_unique_param_pairs(params_affect)
+    
+        cb = (sys.V > sys.θ) => (
+            generic_spike_affect!, 
+            states_affect, 
+            param_pairs, 
+            [], 
+            nothing
+        )
+
+        return cb
+    end
+end
+
+function generate_discrete_callbacks(blox::Union{LIFExciNeuron, LIFInhNeuron}, bc::Connector; t_block = missing)
+    sa = spike_affects(bc)
+    name_blox = namespaced_nameof(blox)
+    sys = get_namespaced_sys(blox)
+
+    states_affect = get_states_spikes_affect(sa, name_blox)
+    params_affect = get_params_spikes_affect(sa, name_blox)
+   
+    param_pairs = make_unique_param_pairs(params_affect)
     
     ps = vcat([
         sys.V_reset => Symbol(sys.V_reset), 
         sys.t_refract_duration => Symbol(sys.t_refract_duration), 
         sys.t_refract_end => Symbol(sys.t_refract_end), 
         sys.is_refractory => Symbol(sys.is_refractory)
-    ], affect_pairs)
+    ], param_pairs)
     
     cb = (sys.V > sys.θ) => (
         LIF_spike_affect!, 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -125,6 +125,8 @@ function LIF_spike_affect!(integ, u, p, ctx)
     end
 end
 
+generate_discrete_callbacks(blox, ::Connector; t_block = missing) = []
+
 function generate_discrete_callbacks(blox::AbstractNeuronBlox, bc::Connector; t_block = missing)
     sa = spike_affects(bc)
     name_blox = namespaced_nameof(blox)

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -1,3 +1,13 @@
+function Base.getproperty(b::Union{AbstractNeuronBlox, NeuralMassBlox}, name::Symbol)
+    # TO DO : Some of the fields below besides `odesystem` and `namespace` 
+    # are redundant and we should clean them up. 
+    if (name === :odesystem) || (name === :namespace) || (name === :params) || (name === :output) || (name === :voltage)
+        return getfield(b, name)
+    else
+        return Base.getproperty(Neuroblox.get_namespaced_sys(b), name)
+    end
+end
+
 """
     function paramscoping(;tunable=true, kwargs...)
     
@@ -150,7 +160,7 @@ end
     which holds a `Connector` object with all relevant connections 
     from lower levels and this level.
 """
-function get_input_equations(blox::Union{AbstractBlox, ObserverBlox})
+function get_input_equations(blox::Union{AbstractBlox, ObserverBlox}; namespaced=true)
     sys = get_system(blox)
     sys_eqs = equations(sys)
 
@@ -158,12 +168,18 @@ function get_input_equations(blox::Union{AbstractBlox, ObserverBlox})
     filter!(inp -> isnothing(find_eq(sys_eqs, inp)), inps)
 
     if !isempty(inps)
-        eqs = map(inps) do inp
-            namespace_equation(
-                inp ~ 0, 
-                sys,
-                namespaced_name(inner_namespaceof(blox), nameof(blox))
-            ) 
+        eqs = if namespaced
+            map(inps) do inp
+                namespace_equation(
+                    inp ~ 0, 
+                    sys,
+                    namespaced_name(inner_namespaceof(blox), nameof(blox))
+                ) 
+            end
+        else
+            map(inps) do inp
+                inp ~ 0
+            end
         end
 
         return eqs

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -84,6 +84,15 @@ get_system(blox) = blox.odesystem
 get_system(sys::AbstractODESystem) = sys
 get_system(stim::PoissonSpikeTrain) = System(Equation[], t, [], []; name=stim.name)
 
+function system(blox::AbstractBlox; simplify=true)
+    sys = get_system(blox)
+    eqs = get_input_equations(blox; namespaced=false)
+
+    csys = System(vcat(equations(sys), eqs), t, unknowns(sys), parameters(sys); name = nameof(sys))
+
+    return simplify ? structural_simplify(csys) : csys
+end
+
 function get_namespaced_sys(blox)
     sys = get_system(blox)
     System(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -299,7 +299,7 @@ function connection_equations(blox_src::AbstractNeuronBlox, blox_dest::AbstractN
     return blox_dest.jcn ~ cr
 end
 
-connection_spike_affects(source, destination) = Tuple{Num, Num}[]
+connection_spike_affects(source, destination, w) = Tuple{Num, Num}[]
 
 function connection_learning_rule(source, destination, w; kwargs...)
     if haskey(kwargs, :learning_rule)
@@ -318,7 +318,7 @@ function Connector(blox_src::AbstractBlox, blox_dest::AbstractBlox; kwargs...)
     lr = connection_learning_rule(blox_src, blox_dest, w; kwargs...)  
     cb = connection_callbacks(blox_src, blox_dest; kwargs...)
 
-    affects_tuple = connection_spike_affects(blox_src, blox_dest)
+    affects_tuple = connection_spike_affects(blox_src, blox_dest, w)
     sa = Dict(namespaced_nameof(blox_src) => to_vector(affects_tuple))  
     
     return Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -965,24 +965,6 @@ end
 
 Connector(blox::AbstractBlox, as::AbstractActionSelection; kwargs...) = Connector(namespaced_nameof(blox), namespaced_nameof(as))
 
-# Connects spiking neuron to another spiking neuron
-# None of these neurons have delay yet
-function Connector(
-    blox_src::AbstractNeuronBlox, 
-    blox_dest::AbstractNeuronBlox; 
-    kwargs...
-)
-    sys_src = get_namespaced_sys(blox_src)
-    sys_dest = get_namespaced_sys(blox_dest)
-
-    w = generate_weight_param(blox_src, blox_dest; kwargs...)
-
-    cr = get_connection_rule(kwargs, blox_src, blox_dest, w)
-    eq = sys_dest.jcn ~ cr
-    
-    return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
-end
-
 # Connects a neural mass as a driving input to a spiking neuron
 # Should be used with care because units will be strange (NMM typically outputs voltage but neuron inputs are typically currents)
 function Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -5,7 +5,7 @@ struct Connector
     weight::Vector{Num}
     delay::Vector{Num}
     discrete_callbacks
-    spike_affects::Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}
+    spike_affects::Dict{Symbol, Vector{Tuple{Num, Num}}}
     learning_rule::Dict{Num, AbstractLearningRule}
 end
 
@@ -16,7 +16,7 @@ function Connector(
     weight=Num[], 
     delay=Num[], 
     discrete_callbacks=[], 
-    spike_affects=Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}(),
+    spike_affects=Dict{Symbol, Vector{Tuple{Num, Num}}}(),
     learning_rule=Dict{Num, AbstractLearningRule}()
     )
 
@@ -82,8 +82,8 @@ function Base.show(io::IO, ::MIME"text/plain", c::Connector)
     for s in c.source
         if haskey(c.spike_affects, s)
             println("$(s) spikes affect :")
-            vars, vals = c.spike_affects[s]
-            for (var, val) in zip(vars, vals)
+            v = c.spike_affects[s]
+            for (var, val) in v
                 println("\t $(var) += $(val)")
             end
         end
@@ -126,13 +126,6 @@ function accumulate_equations(eqs1::Vector{<:Equation}, eqs2::Vector{<:Equation}
     end
 
     return eqs
-end
-
-function tuple_append!(t1::Tuple, t2::Tuple)
-    append!(first(t1), first(t2))
-    append!(last(t1), last(t2))
-
-    return t1
 end
 
 ModelingToolkit.equations(c::Connector) = c.equation
@@ -225,7 +218,7 @@ function Base.merge!(c1::Connector, c2::Connector)
     append!(c1.weight, c2.weight)
     append!(c1.delay, c2.delay)
     append!(c1.discrete_callbacks, c2.discrete_callbacks)
-    mergewith!(tuple_append!, c1.spike_affects, c2.spike_affects)
+    mergewith!(append!, c1.spike_affects, c2.spike_affects)
     merge!(c1.learning_rule, c2.learning_rule)
 
     return c1
@@ -472,7 +465,7 @@ function Connector(
 
     lr = get_learning_rule(kwargs, nameof(sys_src), nameof(sys_dest))
 
-    if typeof(blox_src.output) == Num
+    if blox_src.output isa Num
         x = namespace_expr(blox_src.output, sys_src)
         eq = sys_dest.jcn ~ x*w
 
@@ -1011,9 +1004,9 @@ function Connector(
     # Compare the unique namespaced names of both systems
     sa = if nameof(sys_src) == nameof(sys_dest)
         # x is the rise variable for NMDA synapses and it only applies to self-recurrent connections
-        nameof(sys_src) => ([sys_dest.S_AMPA, sys_dest.x], [w, w])
+        nameof(sys_src) => [(sys_dest.S_AMPA, w), (sys_dest.x, w)]
     else
-        nameof(sys_src) => ([sys_dest.S_AMPA], [w])
+        nameof(sys_src) => [(sys_dest.S_AMPA, w)]
     end
 
     return Connector(nameof(sys_src), nameof(sys_dest); equation = eq, weight = [w], spike_affects = Dict(sa))
@@ -1029,7 +1022,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    sa = nameof(sys_src) => ([sys_dest.S_GABA], [w])
+    sa = nameof(sys_src) => [(sys_dest.S_GABA, w)]
 
     return Connector(nameof(sys_src), nameof(sys_dest); weight = w, spike_affects = Dict(sa))
 end

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -157,6 +157,22 @@ get_equations_with_parameter_lhs(eqs::AbstractVector{<:Equation}) = filter(eq ->
 
 get_equations_with_state_lhs(eqs::AbstractVector{<:Equation}) = filter(eq -> !isparameter(eq.lhs), eqs)
 
+function get_states_spikes_affect(sa, name) 
+    if haskey(sa, name)
+        return first.(sa[name])
+    else
+        Num[]
+    end
+end
+
+function get_params_spikes_affect(sa, name) 
+    if haskey(sa, name)
+        return last.(sa[name])
+    else
+        Num[]
+    end
+end
+
 function generate_weight_param(blox_out, blox_in; kwargs...)
     name_out = namespaced_nameof(blox_out)
     name_in = namespaced_nameof(blox_in)

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -280,19 +280,47 @@ end
 
 connection_rule(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...)
 
-connection_equation(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...).equation
+connection_equations(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...).equation
 
-function connection_equation(blox_src, blox_dest, w) end
+connection_equations(source, destination, w; kwargs...) = Equation[]
 
-function Connector(blox_src, blox_dest::AbstractBlox; kwargs...)
-    sys_src = get_namespaced_sys(blox_src)
-    sys_dest = get_namespaced_sys(blox_dest)
+function connection_equations(blox_src::AbstractNeuronBlox, blox_dest::AbstractNeuronBlox, w; kwargs...)
+    cr = get_connection_rule(kwargs, blox_src, blox_dest, w)
 
+    return sys_dest.jcn ~ cr
+end
+
+connection_spike_affects(source, destination) = Tuple{Num, Num}[]
+
+function connection_learning_rule(source, destination, w; kwargs...)
+    if haskey(kwargs, :learning_rule)
+        return Dict(w => deepcopy(kwargs[:learning_rule]))
+    else
+        return Dict{Num, AbstractLearningRule}()
+    end
+end
+    
+connection_callbacks(source, destination; kwargs...) = []
+
+function Connector(blox_src::AbstractBlox, blox_dest::AbstractBlox; kwargs...)
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    eq = connection_equation(blox_src, blox_dest, w)
+    eq = connection_equations(blox_src, blox_dest, w; kwargs...)
+    lr = connection_learning_rule(blox_src, blox_dest, w; kwargs...)  
+    cb = connection_callbacks(blox_src, blox_dest; kwargs...)
 
-    return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
+    affects_tuple = connection_spike_affects(blox_src, blox_dest)
+    sa = Dict(namespaced_nameof(blox_src) => to_vector(affects_tuple))  
+    
+    return Connector(
+        namespaced_nameof(blox_src), 
+        namespaced_nameof(blox_dest); 
+        equation = eq, 
+        weight = w,
+        spike_affects = sa,
+        discrete_callbacks = cb,
+        learning_rule = lr
+    )
 end
 
 function Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -296,7 +296,7 @@ connection_equations(source, destination, w; kwargs...) = Equation[]
 function connection_equations(blox_src::AbstractNeuronBlox, blox_dest::AbstractNeuronBlox, w; kwargs...)
     cr = get_connection_rule(kwargs, blox_src, blox_dest, w)
 
-    return sys_dest.jcn ~ cr
+    return blox_dest.jcn ~ cr
 end
 
 connection_spike_affects(source, destination) = Tuple{Num, Num}[]

--- a/src/blox/neuron_models.jl
+++ b/src/blox/neuron_models.jl
@@ -628,23 +628,6 @@ struct LIFNeuron <: AbstractNeuronBlox
 	end
 end
 
-function LIF_spike_affect!(integ, u, p, ctx)
-    integ.u[u[1]] = integ.p[p[1]]
-
-    t_refract_end = integ.t + integ.p[p[2]]
-    integ.p[p[3]] = t_refract_end
-
-    integ.p[p[4]] = 1
-
-    SciMLBase.add_tstop!(integ, t_refract_end)
-    
-    c = 1
-    for i in eachindex(u)[2:end]
-        integ.u[u[i]] += integ.p[p[c + 4]]
-        c += 1
-    end
-end
-
 struct LIFInhNeuron <: AbstractInhNeuronBlox
     odesystem
     namespace


### PR DESCRIPTION
Adds a generic dispatch to `Connector` along with functions to be expanded by users when they want to define their own connections. There's one such function per `Connector` field. 

Also adds a couple of convenience functions
- `system(blox; simplify=true)` that returns a (simplified) system to make it easy to simulate a single blox without defining a graph.
- dispatch `Base.getproperty(blox, field::Symbol)` to propagate relevant fields to `blox.odesystem` so one can do `@named blox = LIFNeuron() ; blox.V` to get the namespaced `V` variable instead having to first extract the inner `odesystem`. 