### PR TITLE
Replace `output` field with `MTK.outputs` function and cleanup

### DIFF
--- a/docs/src/tutorials/neural_assembly.jl
+++ b/docs/src/tutorials/neural_assembly.jl
@@ -269,7 +269,7 @@ add_edge!(g, ASC1 => VAC, weight=44)
 add_edge!(g, ASC1 => AC, weight=44)
 add_edge!(g, VAC => AC, weight=3, density=0.08)
 
-## define odesystem and solve
+## define system and solve
 sys = system_from_graph(g, name=global_namespace)
 prob = ODEProblem(sys, [], (0.0, 1000), []) ## tspan = (0,1000)
 sol = solve(prob, Vern7(), saveat=0.1);

--- a/docs/src/tutorials/parkinsons.jl
+++ b/docs/src/tutorials/parkinsons.jl
@@ -138,7 +138,7 @@ sol = solve(prob, Tsit5(), saveat=0.1); ## Solve the problem and save every 0.1m
 # Let's interrogate the solution to see what we have. For the purposes of this tutorial, we'll focus on the striatal oscillations.
 # In this simple model, we should see relatively sharp on/off transitions in the striatal populations. To test this, let's use [Symbolic Indexing](https://docs.sciml.ai/SymbolicIndexingInterface/stable/usage/) to access the states we're interested in: the ``y`` state of the D1 neuron population.
 
-idx_func = ModelingToolkit.getu(sol, D1.odesystem.y); ## gets the state index of the D1 neuron population in the solution object
+idx_func = ModelingToolkit.getu(sol, D1.system.y); ## gets the state index of the D1 neuron population in the solution object
 
 # Now use this indexing function to plot the solution in a Makie plot ([read more about Makie in the docs](https://docs.makie.org/stable/tutorials/getting-started)).
 

--- a/examples/RF_learning_using_BLOX.jl
+++ b/examples/RF_learning_using_BLOX.jl
@@ -157,7 +157,7 @@ end
 # ╔═╡ d80b3bf7-24d8-4395-8903-de974e6445f9
 begin
 	#extract membrane voltages of every neuron
-    getsys=agent.odesystem;
+    getsys=agent.system;
 	st=unknowns(getsys)
 	vlist=Int64[]
 	for ii = 1:length(st)

--- a/examples/cortical_single.jl
+++ b/examples/cortical_single.jl
@@ -298,7 +298,7 @@ begin
 end
 
 # ╔═╡ 84410723-dcb4-46eb-bac4-871aac88cf8c
-#construct odesystems for each neuron and then construct the composite odesystem for entire network using function synaptic_network() 
+#construct odesystems for each neuron and then construct the composite system for entire network using function synaptic_network() 
 begin
 
 	nrn_network=[]
@@ -328,7 +328,7 @@ prob = ODEProblem(syn_net, [], (0, simtime));
 sol = solve(prob,Vern7(),saveat = 0.1)#,saveat = 0.1,reltol=1e-4,abstol=1e-4);
 
 # ╔═╡ 263b26c2-b19b-4889-8e8c-fa3aef952649
-# this extracts indices for input current amplitudes I_in and for weight matrix elements adj from the parameters of the entire odesystem. These are usefull for
+# this extracts indices for input current amplitudes I_in and for weight matrix elements adj from the parameters of the entire system. These are usefull for
 #changing the input currents and weights of already existing connections by remaking #the odeprob 
 begin
 indexof(sym,syms) = findfirst(isequal(sym),syms)

--- a/examples/flattening_circuit/RF_learning_using_BLOX_save_voltages.jl
+++ b/examples/flattening_circuit/RF_learning_using_BLOX_save_voltages.jl
@@ -157,7 +157,7 @@ end
 # ╔═╡ d80b3bf7-24d8-4395-8903-de974e6445f9
 begin
 	#extract membrane voltages of every neuron
-    getsys=agent.odesystem;
+    getsys=agent.system;
 	st=unknowns(getsys)
 	vlist=Int64[]
 	for ii = 1:length(st)

--- a/examples/makiepowerplot.jl
+++ b/examples/makiepowerplot.jl
@@ -21,7 +21,7 @@ sol = solve(prob, Vern7(), saveat=0.01)
 fss = powerspectrumplot(cb, sol)
 
 @named msn = Striatum_MSN_Adam();
-sys = structural_simplify(msn.odesystem)
+sys = structural_simplify(msn.system)
 prob = SDEProblem(sys, [], (0.0, 5500), [])
 sol = solve(prob, RKMil(), dt=0.05, saveat=0.01)
 

--- a/examples/rasterplot_firing_rate.jl
+++ b/examples/rasterplot_firing_rate.jl
@@ -4,7 +4,7 @@ using CairoMakie # due to a bug in CairoMakie, we need to use CairoMakie@0.11
 
 
 @named msn = Striatum_MSN_Adam(I_bg = 1.172*ones(100), σ = 0.11);
-sys = structural_simplify(msn.odesystem)
+sys = structural_simplify(msn.system)
 prob = SDEProblem(sys, [], (0.0, 5500.0), [])
 sol = solve(prob, RKMil(); dt=0.05, saveat=0.05)
 

--- a/examples/signals.jl
+++ b/examples/signals.jl
@@ -40,7 +40,7 @@ begin
 	@named Str2 = jansen_ritC(τ=0.0022, H=20, λ=300, r=0.3)
 	@parameters phase_input=0 ampl=1
 
-	sys = [Str2.odesystem]
+	sys = [Str2.system]
 	eqs = [sys[1].jcn ~ ampl*phase_input]
 	@named phase_system = ODESystem(eqs,systems=sys)
 	phase_system_simpl = structural_simplify(phase_system)

--- a/examples/wilson_cowan.jl
+++ b/examples/wilson_cowan.jl
@@ -39,7 +39,7 @@ end
 
 # ╔═╡ 9f3d6efd-a884-449c-b4b8-42b0b435e245
 begin
-	sys = [WC.odesystem]
+	sys = [WC.system]
 	eqs = [sys[1].jcn ~ 0.0, sys[1].P ~ 0.0]
 	@named WC_sys = ODESystem(eqs,systems=sys)
 end

--- a/examples/wilson_cowan2.jl
+++ b/examples/wilson_cowan2.jl
@@ -39,7 +39,7 @@ end
 # ╔═╡ 9f3d6efd-a884-449c-b4b8-42b0b435e245
 begin
 	blox = [WC1,WC2]
-	sys = [b.odesystem for b in blox]
+	sys = [b.system for b in blox]
 	connect = [b.connector for b in blox]
 end
 

--- a/examples/wilson_cowan2s.jl
+++ b/examples/wilson_cowan2s.jl
@@ -40,7 +40,7 @@ end
 # ╔═╡ 9f3d6efd-a884-449c-b4b8-42b0b435e245
 begin
 	blox = [WC1,WC2]
-	sys = [b.odesystem for b in blox]
+	sys = [b.system for b in blox]
 	connect = [b.connector for b in blox]
 end
 

--- a/ext/MakieExtension.jl
+++ b/ext/MakieExtension.jl
@@ -4,7 +4,7 @@ isdefined(Base, :get_extension) ? using Makie : using ..Makie
 
 using Neuroblox
 using Neuroblox: AbstractBlox, AbstractNeuronBlox, CompositeBlox, VLState, VLSetup
-using Neuroblox: meanfield_timeseries, voltage_timeseries, detect_spikes, firing_rate, get_neurons, get_adjacency
+using Neuroblox: meanfield_timeseries, voltage_timeseries, detect_spikes, firing_rate, get_neurons
 using Neuroblox: powerspectrum
 using SciMLBase: AbstractSolution, EnsembleSolution
 using LinearAlgebra: diag
@@ -20,7 +20,7 @@ import Neuroblox: powerspectrumplot, powerspectrumplot!
 
 @recipe(Adjacency, blox_or_graph) do scene
     Theme(
-        colormap = :vanimo
+        colormap = :grays
     )
 end
 
@@ -28,7 +28,7 @@ argument_names(::Type{<: Adjacency}) = (:blox_or_graph)
 
 function Makie.plot!(p::Adjacency)
     blox_or_graph = p.blox_or_graph[]
-    adj = get_adjacency(blox_or_graph)
+    adj = AdjacencyMatrix(blox_or_graph)
 
     N = length(adj.names)
 
@@ -42,7 +42,7 @@ function Makie.plot!(p::Adjacency)
 
     X, Y, D = findnz(adj.matrix)
 
-    heatmap!(p, X, Y, D; colormap = p.colormap[], colorrange = (minimum(D), maximum(D)))
+    heatmap!(p, Y, X, D; colormap = p.colormap[])
 
     return p
 end

--- a/src/GraphDynamicsInterop/connection_interop.jl
+++ b/src/GraphDynamicsInterop/connection_interop.jl
@@ -29,7 +29,7 @@ function generate_gap_weight_param(blox_src, blox_dst, kwargs)
         name = nameof(w)
     else
         w_val = w
-        name = Symbol("g_w_$(nameof(blox_src.odesystem))_$(nameof(blox_dst.odesystem))")
+        name = Symbol("g_w_$(nameof(blox_src.system))_$(nameof(blox_dst.system))")
     end
     (;w_val, name)
 end
@@ -476,7 +476,7 @@ end
 #             name_presyn = namespaced_nameof(neuron_presyn)
 #             # Check names to avoid recurrent connections between the same neuron
 #             if (name_postsyn != name_presyn) && rand(rng, dist)
-#                 w_name = Symbol("w_$(nameof(neuron_presyn.odesystem))_$(nameof(neuron_postsyn.odesystem))")
+#                 w_name = Symbol("w_$(nameof(neuron_presyn.system))_$(nameof(neuron_postsyn.system))")
 #                 (; conn) = get_connection(neuron_presyn, neuron_postsyn, kwargs)
 #                 add_edge!(h, v_dst[j], v_src[i], Dict(:conn => conn, :names => [w_name]))
 #             end

--- a/src/GraphDynamicsInterop/neuron_interop.jl
+++ b/src/GraphDynamicsInterop/neuron_interop.jl
@@ -113,7 +113,7 @@ function define_neurons()
         end
         
         outs = Neuroblox.outputs(sys)
-        if !isempty(outs)
+        if length(outs) == 1
             out = only(outs)
             output_sym = hasproperty(out.val, :f) ? Symbol(out.val.f) : Symbol(out.val)
             @eval output(s::Subsystem{$T}) = s.$output_sym

--- a/src/GraphDynamicsInterop/neuron_interop.jl
+++ b/src/GraphDynamicsInterop/neuron_interop.jl
@@ -35,7 +35,7 @@ function define_neurons()
                      (:pinhib, :PINGNeuronInhib)
                      ]
         sys = getproperty(Neuroblox, T)(;name)
-        system = structural_simplify(sys.odesystem; fully_determined=false)
+        system = structural_simplify(sys.system; fully_determined=false)
         params = get_ps(system)
         t = Symbol(get_iv(system))
 
@@ -168,7 +168,7 @@ GraphDynamics.subsystem_differential_requires_inputs(::Type{PoissonSpikeTrain}) 
 issupported(::KuramotoOscillator) = true
 function to_subsystem(o::KuramotoOscillator)
     states = SubsystemStates{KuramotoOscillator}((;θ=0.0,))
-    params = SubsystemParams{KuramotoOscillator}((;ω=getdefault(o.odesystem.ω), ζ=getdefault(o.odesystem.ζ)))
+    params = SubsystemParams{KuramotoOscillator}((;ω=getdefault(o.system.ω), ζ=getdefault(o.system.ζ)))
     Subsystem(states, params)
 end
 
@@ -238,8 +238,8 @@ function GraphDynamics.apply_subsystem_differential!(_, s::Subsystem{TAN}, jcn, 
 end
 GraphDynamics.subsystem_differential_requires_inputs(::Type{TAN}) = false
 function to_subsystem(s::TAN)
-    κ = getdefault(s.odesystem.κ)
-    λ = getdefault(s.odesystem.λ)
+    κ = getdefault(s.system.κ)
+    λ = getdefault(s.system.λ)
     states = SubsystemStates{TAN, Float64, @NamedTuple{}}((;))
     params = SubsystemParams{TAN}((; κ, λ))
     #TODO: support observed variable R = min(κ, κ/(λ*jcn + sqrt(eps())))
@@ -259,8 +259,8 @@ GraphDynamics.subsystem_differential_requires_inputs(::Type{SNc}) = false
 function to_subsystem(s::SNc)
     (;N_time_blocks, κ_DA, DA_reward) = s
     
-    κ = getdefault(s.odesystem.κ)
-    λ = getdefault(s.odesystem.λ)
+    κ = getdefault(s.system.κ)
+    λ = getdefault(s.system.λ)
     states = SubsystemStates{SNc, Float64, @NamedTuple{}}((;))
     params = SubsystemParams{TAN}((;κ_DA, N_time_blocks, DA_reward, λ_DA, t_event=t_event+sqrt(eps(t_event)), jcn_=0.0))
     #TODO: support observed variables R  ~ min(κ_DA, κ_DA/(λ_DA*jcn  + sqrt(eps())))

--- a/src/GraphDynamicsInterop/neuron_interop.jl
+++ b/src/GraphDynamicsInterop/neuron_interop.jl
@@ -112,8 +112,10 @@ function define_neurons()
             end
         end
         
-        if hasproperty(sys, :output)
-            output_sym = hasproperty(sys.output.val, :f) ? Symbol(sys.output.val.f) : Symbol(sys.output.val)
+        outs = Neuroblox.outputs(sys)
+        if !isempty(outs)
+            out = only(outs)
+            output_sym = hasproperty(out.val, :f) ? Symbol(out.val.f) : Symbol(out.val)
             @eval output(s::Subsystem{$T}) = s.$output_sym
         end
         

--- a/src/GraphDynamicsInterop/neuron_interop.jl
+++ b/src/GraphDynamicsInterop/neuron_interop.jl
@@ -112,7 +112,7 @@ function define_neurons()
             end
         end
         
-        outs = Neuroblox.outputs(sys)
+        outs = Neuroblox.outputs(sys; namespaced=false)
         if length(outs) == 1
             out = only(outs)
             output_sym = hasproperty(out.val, :f) ? Symbol(out.val.f) : Symbol(out.val)

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -40,7 +40,7 @@ using SciMLBase: SciMLBase, AbstractSolution, solve, remake
 using ModelingToolkit: get_namespace, get_systems, isparameter,
                     renamespace, namespace_equation, namespace_parameters, namespace_expr,
                     AbstractODESystem, VariableTunable, getp
-import ModelingToolkit: equations, inputs, outputs, nameof, getdescription
+import ModelingToolkit: equations, inputs, outputs, unknowns, parameters, discrete_events, nameof, getdescription
 
 using Symbolics: @register_symbolic, getdefaultval, get_variables
 
@@ -257,5 +257,5 @@ export powerspectrumplot, powerspectrumplot!, welch_pgram, periodogram, hanning,
 export detect_spikes, mean_firing_rate, firing_rate
 export voltage_timeseries, meanfield_timeseries, state_timeseries, get_neurons, get_exci_neurons, get_inh_neurons, get_neuron_color
 export AdjacencyMatrix, Connector, connection_rule, connection_equations, connection_spike_affects, connection_learning_rules, connection_callbacks
-export outputs
+export inputs, outputs, equations, unknowns, parameters, discrete_events
 end

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -131,9 +131,9 @@ function simulate(sys::ODESystem, u0, timespan, p, solver = AutoVern7(Rodas4());
 end
 
 function simulate(blox::CorticalBlox, u0, timespan, p, solver = AutoVern7(Rodas4()); kwargs...)
-    prob = ODEProblem(blox.odesystem, u0, timespan, p)
+    prob = ODEProblem(blox.system, u0, timespan, p)
     sol = solve(prob, solver; kwargs...) # pass keyword arguments to solver
-    statesV = [s for s in unknowns(blox.odesystem) if contains(string(s),"V")]
+    statesV = [s for s in unknowns(blox.system) if contains(string(s),"V")]
     vsol = sol[statesV]
     vmean = vec(mean(hcat(vsol...),dims=2))
     df = DataFrame(sol)

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -223,6 +223,7 @@ function __init__()
 end
 
 
+export Neuron
 export JansenRitSPM12, next_generation, qif_neuron, if_neuron, hh_neuron_excitatory, 
     hh_neuron_inhibitory, van_der_pol, Generic2dOscillator
 export HHNeuronExciBlox, HHNeuronInhibBlox, IFNeuron, LIFNeuron, QIFNeuron, IzhikevichNeuron, LIFExciNeuron, LIFInhNeuron,
@@ -243,7 +244,7 @@ export powerspectrum, complexwavelet, bandpassfilter, hilberttransform, phaseang
 export learningrate, ControlError
 export vecparam, csd_Q, setup_sDCM, run_sDCM_iteration!, defaultprior
 export simulate, random_initials
-export system_from_graph, graph_delays
+export system_from_graph, system, graph_delays
 export create_adjacency_edges!, adjmatrixfromdigraph
 export get_namespaced_sys, nameof
 export run_experiment!, run_trial!
@@ -256,5 +257,5 @@ export meanfield, meanfield!, rasterplot, rasterplot!, stackplot, stackplot!, fr
 export powerspectrumplot, powerspectrumplot!, welch_pgram, periodogram, hanning, hamming
 export detect_spikes, mean_firing_rate, firing_rate
 export voltage_timeseries, meanfield_timeseries, state_timeseries, get_neurons, get_exci_neurons, get_inh_neurons, get_neuron_color
-export AdjacencyMatrix, Connector, connection_rule, connection_equation
+export AdjacencyMatrix, Connector, connection_rule, connection_equations, connection_spike_affects, connection_learning_rules, connection_callbacks
 end

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -37,11 +37,10 @@ using Distributions
 
 using SciMLBase: SciMLBase, AbstractSolution, solve, remake
 
-
 using ModelingToolkit: get_namespace, get_systems, isparameter,
                     renamespace, namespace_equation, namespace_parameters, namespace_expr,
                     AbstractODESystem, VariableTunable, getp
-import ModelingToolkit: equations, inputs, nameof, getdescription
+import ModelingToolkit: equations, inputs, outputs, nameof, getdescription
 
 using Symbolics: @register_symbolic, getdefaultval, get_variables
 
@@ -258,4 +257,5 @@ export powerspectrumplot, powerspectrumplot!, welch_pgram, periodogram, hanning,
 export detect_spikes, mean_firing_rate, firing_rate
 export voltage_timeseries, meanfield_timeseries, state_timeseries, get_neurons, get_exci_neurons, get_inh_neurons, get_neuron_color
 export AdjacencyMatrix, Connector, connection_rule, connection_equations, connection_spike_affects, connection_learning_rules, connection_callbacks
+export outputs
 end

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -68,6 +68,7 @@ abstract type StimulusBlox <: AbstractBlox end
 abstract type ObserverBlox end # not AbstractBlox since it should not show up in the GUI
 abstract type AbstractPINGNeuron <: AbstractNeuronBlox end
 
+const Neuron = AbstractNeuronBlox
 
 # we define these in neural_mass.jl
 # abstract type HarmonicOscillatorBlox <: NeuralMassBlox end

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -8,9 +8,8 @@ using OhMyThreads: tmapreduce
 
 using Reexport
 @reexport using ModelingToolkit
-const t = ModelingToolkit.t_nounits
-const D = ModelingToolkit.D_nounits
-export t, D
+@reexport using ModelingToolkit: ModelingToolkit.t_nounits as t, ModelingToolkit.D_nounits as D
+
 @reexport using ModelingToolkitStandardLibrary.Blocks
 @reexport import Graphs: add_edge!
 @reexport using MetaGraphs: MetaDiGraph

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -81,37 +81,91 @@ function graph_delays(g::MetaDiGraph)
     return conn.delay
 end
 
-generate_discrete_callbacks(blox, ::Connector; t_block = missing) = []
-
-function generate_discrete_callbacks(blox::Union{LIFExciNeuron, LIFInhNeuron}, bc::Connector; t_block = missing)
-    sa = spike_affects(bc)
-    name_blox = namespaced_nameof(blox)
-    sys = get_namespaced_sys(blox)
-
-    states_affect, params_affect = get(sa, name_blox, (Num[], Num[]))
-
+function make_unique_param_pairs(params)
     # HACK : MTK will complain if the parameter vector passed to a functional affect
     # contains non-unique parameters. Here we sometimes need to pass duplicate parameters that 
     # affect states in the loop in LIF_spike_affect! .
     # Passing parameters with Symbol aliases bypasses this issue and allows for duplicates. 
-    affect_pairs = if unique(params_affect) == length(params_affect)
-        [p => Symbol(p) for p in params_affect]
+    param_pairs = if unique(params) == length(params)
+        [p => Symbol(p) for p in params]
     else
-        map(params_affect) do p
-            if count(pi -> Symbol(pi) == Symbol(p), params_affect) > 1
+        map(params) do p
+            if count(pi -> Symbol(pi) == Symbol(p), params) > 1
                 p => Symbol(p, "_$(rand(1:1000))")
             else
                 p => Symbol(p)
             end
         end
     end
+
+    return param_pairs
+end
+
+function generic_spike_affect!(integ, u, p, ctx)
+    N = length(u)
+    for i in Base.OneTo(N)
+        integ.u[u[i]] += integ.p[p[i]]
+    end
+end
+
+function LIF_spike_affect!(integ, u, p, ctx)
+    integ.u[u[1]] = integ.p[p[1]]
+
+    t_refract_end = integ.t + integ.p[p[2]]
+    integ.p[p[3]] = t_refract_end
+
+    integ.p[p[4]] = 1
+
+    SciMLBase.add_tstop!(integ, t_refract_end)
+    
+    c = 1
+    for i in eachindex(u)[2:end]
+        integ.u[u[i]] += integ.p[p[c + 4]]
+        c += 1
+    end
+end
+
+function generate_discrete_callbacks(blox::AbstractNeuronBlox, bc::Connector; t_block = missing)
+    sa = spike_affects(bc)
+    name_blox = namespaced_nameof(blox)
+    sys = get_namespaced_sys(blox)
+
+    states_affect = get_states_spikes_affect(sa, name_blox)
+    params_affect = get_params_spikes_affect(sa, name_blox)
+    
+    if isempty(states_affect) && isempty(params_affect)
+        return []
+    else
+        param_pairs = make_unique_param_pairs(params_affect)
+    
+        cb = (sys.V > sys.θ) => (
+            generic_spike_affect!, 
+            states_affect, 
+            param_pairs, 
+            [], 
+            nothing
+        )
+
+        return cb
+    end
+end
+
+function generate_discrete_callbacks(blox::Union{LIFExciNeuron, LIFInhNeuron}, bc::Connector; t_block = missing)
+    sa = spike_affects(bc)
+    name_blox = namespaced_nameof(blox)
+    sys = get_namespaced_sys(blox)
+
+    states_affect = get_states_spikes_affect(sa, name_blox)
+    params_affect = get_params_spikes_affect(sa, name_blox)
+   
+    param_pairs = make_unique_param_pairs(params_affect)
     
     ps = vcat([
         sys.V_reset => Symbol(sys.V_reset), 
         sys.t_refract_duration => Symbol(sys.t_refract_duration), 
         sys.t_refract_end => Symbol(sys.t_refract_end), 
         sys.is_refractory => Symbol(sys.is_refractory)
-    ], affect_pairs)
+    ], param_pairs)
     
     cb = (sys.V > sys.θ) => (
         LIF_spike_affect!, 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -53,7 +53,7 @@ get_dynamics_bloxs(blox::CompositeBlox) = get_parts(blox)
 flatten_graph(g::MetaDiGraph) = mapreduce(get_dynamics_bloxs, vcat, get_bloxs(g))
 
 function connectors_from_graph(g::MetaDiGraph)
-    conns = get_connector.(get_bloxs(g))
+    conns = reduce(vcat, get_connectors.(get_bloxs(g)))
     for edge in edges(g)
 
         blox_src = get_prop(g, edge.src, :blox)
@@ -188,22 +188,25 @@ function system_from_graph(g::MetaDiGraph, p::Vector{Num}=Num[]; name=nothing, t
             throw(UndefKeywordError(:name))
         end
         
-        bc = connector_from_graph(g)
+        conns = connectors_from_graph(g)
     
-        return system_from_graph(g, bc, p; name, t_block, simplify, kwargs...)
+        return system_from_graph(g, conns, p; name, t_block, simplify, kwargs...)
     end
 end
 
-function system_from_graph(g::MetaDiGraph, bc::Connector, p::Vector{Num}=Num[]; name=nothing, t_block=missing, simplify=true, graphdynamics=false, kwargs...)
+function system_from_graph(g::MetaDiGraph, conns::AbstractVector{<:Connector}, p::Vector{Num}=Num[]; name=nothing, t_block=missing, simplify=true, graphdynamics=false, kwargs...)
     bloxs = get_bloxs(g)
     blox_syss = get_system.(bloxs)
 
+    bc = isempty(conns) ? Connector(name, name) : reduce(merge!, conns)
+
     eqs = equations(bc)
-    accumulate_equations!(eqs, bloxs)
+    eqs_init = mapreduce(get_input_equations, vcat, bloxs)
+    accumulate_equations!(eqs_init, eqs)
 
-    connection_eqs = get_equations_with_state_lhs(eqs)
+    connection_eqs = get_equations_with_state_lhs(eqs_init)
 
-    discrete_cbs = identity.(generate_discrete_callbacks(g, bc, eqs; t_block))
+    discrete_cbs = identity.(generate_discrete_callbacks(g, bc, eqs_init; t_block))
 
     sys = compose(System(connection_eqs, t, [], vcat(params(bc), p); name, discrete_events = discrete_cbs), blox_syss)
     if simplify

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -125,6 +125,8 @@ function LIF_spike_affect!(integ, u, p, ctx)
     end
 end
 
+generate_discrete_callbacks(blox, ::Connector; t_block = missing) = []
+
 function generate_discrete_callbacks(blox::AbstractNeuronBlox, bc::Connector; t_block = missing)
     sa = spike_affects(bc)
     name_blox = namespaced_nameof(blox)

--- a/src/blox/DBS_Model_Blox_Adam_Brown.jl
+++ b/src/blox/DBS_Model_Blox_Adam_Brown.jl
@@ -106,7 +106,7 @@ struct Striatum_MSN_Adam <: CompositeBlox
         end
         parts = n_inh
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
 
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
@@ -185,7 +185,7 @@ struct Striatum_FSI_Adam  <: CompositeBlox
 
         parts = n_inh
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
 
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
@@ -255,7 +255,7 @@ struct GPe_Adam <: CompositeBlox
         end
         parts = n_inh
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
 
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
@@ -324,7 +324,7 @@ struct STN_Adam <: CompositeBlox
         end
         parts = n_exci
     
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
 
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         

--- a/src/blox/DBS_Model_Blox_Adam_Brown.jl
+++ b/src/blox/DBS_Model_Blox_Adam_Brown.jl
@@ -54,7 +54,7 @@ end
 struct Striatum_MSN_Adam <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
     connection_matrix
@@ -124,7 +124,7 @@ end
 struct Striatum_FSI_Adam  <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
     connection_matrix
@@ -205,7 +205,7 @@ end
 struct GPe_Adam <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
     connection_matrix
@@ -274,7 +274,7 @@ end
 struct STN_Adam <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
     connection_matrix

--- a/src/blox/DBS_sources.jl
+++ b/src/blox/DBS_sources.jl
@@ -1,7 +1,7 @@
 # Defines a DBS (Deep Brain Stimulation) stimulus that can be either continuous or burst protocol
 struct DBS <: StimulusBlox
     params::Vector{Num}
-    odesystem::ODESystem
+    system::ODESystem
     namespace::Union{Symbol, Nothing}
     stimulus::Function
 end

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -1,7 +1,7 @@
 function Base.getproperty(b::Union{AbstractNeuronBlox, NeuralMassBlox}, name::Symbol)
-    # TO DO : Some of the fields below besides `odesystem` and `namespace` 
+    # TO DO : Some of the fields below besides `system` and `namespace` 
     # are redundant and we should clean them up. 
-    if (name === :odesystem) || (name === :namespace) || (name === :params)
+    if (name === :system) || (name === :namespace) || (name === :params)
         return getfield(b, name)
     else
         return Base.getproperty(Neuroblox.get_namespaced_sys(b), name)
@@ -90,7 +90,7 @@ function get_discrete_parts(b::Union{AbstractComponent, CompositeBlox})
     mapreduce(x -> get_discrete_parts(x), vcat, b.parts)
 end
 
-get_system(blox) = blox.odesystem
+get_system(blox) = blox.system
 get_system(sys::AbstractODESystem) = sys
 get_system(stim::PoissonSpikeTrain) = System(Equation[], t, [], []; name=stim.name)
 
@@ -277,7 +277,7 @@ function get_learning_rule(kwargs, name_src, name_dest)
 end
 
 function get_weights(agent::Agent, blox_out, blox_in)
-    ps = parameters(agent.odesystem)
+    ps = parameters(agent.system)
     pv = agent.problem.p
     map_idxs = Int.(ModelingToolkit.varmap_to_vars([ps[i] => i for i in eachindex(ps)], ps))
 

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -147,11 +147,11 @@ function find_eq(eqs::Union{AbstractVector{<:Equation}, Equation}, lhs)
     end
 end
 
-function ModelingToolkit.outputs(blox::AbstractBlox)
+function ModelingToolkit.outputs(blox::AbstractBlox; namespaced=true)
     sys = get_namespaced_sys(blox)
     
     # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
-    return Num.(namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys)))
+    return namespaced ? Num.(namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys))) : Num.(ModelingToolkit.outputs(sys))
 end 
 
 """

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -1,3 +1,13 @@
+function Base.getproperty(b::Union{AbstractNeuronBlox, NeuralMassBlox}, name::Symbol)
+    # TO DO : Some of the fields below besides `odesystem` and `namespace` 
+    # are redundant and we should clean them up. 
+    if (name === :odesystem) || (name === :namespace) || (name === :params) || (name === :output) || (name === :voltage)
+        return getfield(b, name)
+    else
+        return Base.getproperty(Neuroblox.get_namespaced_sys(b), name)
+    end
+end
+
 """
     function paramscoping(;tunable=true, kwargs...)
     
@@ -150,7 +160,7 @@ end
     which holds a `Connector` object with all relevant connections 
     from lower levels and this level.
 """
-function get_input_equations(blox::Union{AbstractBlox, ObserverBlox})
+function get_input_equations(blox::Union{AbstractBlox, ObserverBlox}; namespaced=true)
     sys = get_system(blox)
     sys_eqs = equations(sys)
 
@@ -158,12 +168,18 @@ function get_input_equations(blox::Union{AbstractBlox, ObserverBlox})
     filter!(inp -> isnothing(find_eq(sys_eqs, inp)), inps)
 
     if !isempty(inps)
-        eqs = map(inps) do inp
-            namespace_equation(
-                inp ~ 0, 
-                sys,
-                namespaced_name(inner_namespaceof(blox), nameof(blox))
-            ) 
+        eqs = if namespaced
+            map(inps) do inp
+                namespace_equation(
+                    inp ~ 0, 
+                    sys,
+                    namespaced_name(inner_namespaceof(blox), nameof(blox))
+                ) 
+            end
+        else
+            map(inps) do inp
+                inp ~ 0
+            end
         end
 
         return eqs

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -150,7 +150,8 @@ end
 function ModelingToolkit.outputs(blox::AbstractBlox)
     sys = get_namespaced_sys(blox)
     
-    return namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys))
+    # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
+    return Num.(namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys)))
 end 
 
 """

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -105,12 +105,14 @@ end
 
 function get_namespaced_sys(blox)
     sys = get_system(blox)
+
     System(
         equations(sys), 
         only(independent_variables(sys)), 
         unknowns(sys), 
         parameters(sys); 
-        name = namespaced_nameof(blox)
+        name = namespaced_nameof(blox),
+        discrete_events = discrete_events(sys)
     ) 
 end
 
@@ -153,6 +155,21 @@ function ModelingToolkit.outputs(blox::AbstractBlox; namespaced=false)
     # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
     return namespaced ? Num.(namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys))) : Num.(ModelingToolkit.outputs(sys))
 end 
+
+function ModelingToolkit.inputs(blox::AbstractBlox; namespaced=false)
+    sys = get_system(blox)
+    
+    # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
+    return namespaced ? Num.(namespace_expr.(ModelingToolkit.inputs(sys), Ref(sys))) : Num.(ModelingToolkit.inputs(sys))
+end 
+
+ModelingToolkit.equations(blox::AbstractBlox) = ModelingToolkit.equations(get_system(blox))
+
+ModelingToolkit.discrete_events(blox::AbstractBlox) = ModelingToolkit.discrete_events(get_system(blox))
+
+ModelingToolkit.unknowns(blox::AbstractBlox) = ModelingToolkit.unknowns(get_system(blox))
+
+ModelingToolkit.parameters(blox::AbstractBlox) = ModelingToolkit.parameters(get_system(blox))
 
 """
     Returns the equations for all input variables of a system, 

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -147,8 +147,8 @@ function find_eq(eqs::Union{AbstractVector{<:Equation}, Equation}, lhs)
     end
 end
 
-function ModelingToolkit.outputs(blox::AbstractBlox; namespaced=true)
-    sys = get_namespaced_sys(blox)
+function ModelingToolkit.outputs(blox::AbstractBlox; namespaced=false)
+    sys = get_system(blox)
     
     # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
     return namespaced ? Num.(namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys))) : Num.(ModelingToolkit.outputs(sys))

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -84,6 +84,15 @@ get_system(blox) = blox.odesystem
 get_system(sys::AbstractODESystem) = sys
 get_system(stim::PoissonSpikeTrain) = System(Equation[], t, [], []; name=stim.name)
 
+function system(blox::AbstractBlox; simplify=true)
+    sys = get_system(blox)
+    eqs = get_input_equations(blox; namespaced=false)
+
+    csys = System(vcat(equations(sys), eqs), t, unknowns(sys), parameters(sys); name = nameof(sys))
+
+    return simplify ? structural_simplify(csys) : csys
+end
+
 function get_namespaced_sys(blox)
     sys = get_system(blox)
     System(

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -1,7 +1,7 @@
 function Base.getproperty(b::Union{AbstractNeuronBlox, NeuralMassBlox}, name::Symbol)
     # TO DO : Some of the fields below besides `odesystem` and `namespace` 
     # are redundant and we should clean them up. 
-    if (name === :odesystem) || (name === :namespace) || (name === :params) || (name === :output) || (name === :voltage)
+    if (name === :odesystem) || (name === :namespace) || (name === :params)
         return getfield(b, name)
     else
         return Base.getproperty(Neuroblox.get_namespaced_sys(b), name)
@@ -146,6 +146,12 @@ function find_eq(eqs::Union{AbstractVector{<:Equation}, Equation}, lhs)
         length(lhs_vars) == 1 && isequal(only(lhs_vars), lhs)
     end
 end
+
+function ModelingToolkit.outputs(blox::AbstractBlox)
+    sys = get_namespaced_sys(blox)
+    
+    return namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys))
+end 
 
 """
     Returns the equations for all input variables of a system, 
@@ -382,8 +388,14 @@ function get_connection_rule(kwargs, bloxout, bloxin, w)
 
      # Logic based on connection rule type
      if isequal(cr, "basic")
-        x = namespace_expr(bloxout.output, sys_out)
-        rhs = x*w
+        outs = outputs(bloxout)
+        if !isempty(outs)
+            x = first(outs)
+            rhs = x*w
+            length(outs) > 1 && @warn "Blox $name_blox1 has more than one outputs. Defaulting to output=$x"
+        else
+            error("Blox $name_blox1 has no outputs. Please assign [output=true] to the variables you want to use as outputs or write a dispatch for connection_equations.")
+        end
     elseif isequal(cr, "psp")
         rhs = w*sys_out.G*(sys_out.E_syn - sys_in.V)
     else

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -150,26 +150,26 @@ function find_eq(eqs::Union{AbstractVector{<:Equation}, Equation}, lhs)
 end
 
 function ModelingToolkit.outputs(blox::AbstractBlox; namespaced=false)
-    sys = get_system(blox)
+    sys = get_namespaced_sys(blox)
     
     # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
     return namespaced ? Num.(namespace_expr.(ModelingToolkit.outputs(sys), Ref(sys))) : Num.(ModelingToolkit.outputs(sys))
 end 
 
 function ModelingToolkit.inputs(blox::AbstractBlox; namespaced=false)
-    sys = get_system(blox)
+    sys = get_namespaced_sys(blox)
     
     # Wrap in Num for convenience when checking `isa Num` to resolve delay or no delay connection.
     return namespaced ? Num.(namespace_expr.(ModelingToolkit.inputs(sys), Ref(sys))) : Num.(ModelingToolkit.inputs(sys))
 end 
 
-ModelingToolkit.equations(blox::AbstractBlox) = ModelingToolkit.equations(get_system(blox))
+ModelingToolkit.equations(blox::AbstractBlox) = ModelingToolkit.equations(get_namespaced_sys(blox))
 
-ModelingToolkit.discrete_events(blox::AbstractBlox) = ModelingToolkit.discrete_events(get_system(blox))
+ModelingToolkit.discrete_events(blox::AbstractBlox) = ModelingToolkit.discrete_events(get_namespaced_sys(blox))
 
-ModelingToolkit.unknowns(blox::AbstractBlox) = ModelingToolkit.unknowns(get_system(blox))
+ModelingToolkit.unknowns(blox::AbstractBlox) = ModelingToolkit.unknowns(get_namespaced_sys(blox))
 
-ModelingToolkit.parameters(blox::AbstractBlox) = ModelingToolkit.parameters(get_system(blox))
+ModelingToolkit.parameters(blox::AbstractBlox) = ModelingToolkit.parameters(get_namespaced_sys(blox))
 
 """
     Returns the equations for all input variables of a system, 
@@ -406,7 +406,7 @@ function get_connection_rule(kwargs, bloxout, bloxin, w)
 
      # Logic based on connection rule type
      if isequal(cr, "basic")
-        outs = outputs(bloxout)
+        outs = outputs(bloxout; namespaced=true)
         if !isempty(outs)
             x = first(outs)
             rhs = x*w

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -165,7 +165,10 @@ end
 
 get_input_equations(blox) = []
 
-get_connector(blox::Union{CompositeBlox, Agent}) = blox.connector
+get_connectors(blox::Union{CompositeBlox, Agent}) = blox.connector
+get_connectors(blox) = [Connector(namespaced_nameof(blox), namespaced_nameof(blox))]
+
+get_connector(blox::Union{CompositeBlox, Agent}) = reduce(merge!, get_connectors(blox))
 get_connector(blox) = Connector(namespaced_nameof(blox), namespaced_nameof(blox))
 
 function get_weight(kwargs, name_blox1, name_blox2)

--- a/src/blox/canonicalmicrocircuit.jl
+++ b/src/blox/canonicalmicrocircuit.jl
@@ -5,7 +5,7 @@ Jansen-Rit model block for canonical micro circuit, analogous to the implementat
 """
 mutable struct JansenRitSPM12 <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
     function JansenRitSPM12(;name, namespace=nothing, τ=1.0, r=2.0/3.0)
         p = paramscoping(τ=τ, r=r)
@@ -23,7 +23,7 @@ end
 mutable struct CanonicalMicroCircuitBlox <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
 
     function CanonicalMicroCircuitBlox(;name, namespace=nothing, τ_ss=0.002, τ_sp=0.002, τ_ii=0.016, τ_dp=0.028, r_ss=2.0/3.0, r_sp=2.0/3.0, r_ii=2.0/3.0, r_dp=2.0/3.0)

--- a/src/blox/canonicalmicrocircuit.jl
+++ b/src/blox/canonicalmicrocircuit.jl
@@ -48,7 +48,7 @@ mutable struct CanonicalMicroCircuitBlox <: CompositeBlox
         add_edge!(g, ii => dp; :weight => -400.0)
         add_edge!(g, dp => dp; :weight => -200.0)
 
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         # If a namespace is not provided, assume that this is the highest level
         # and construct the ODEsystem from the graph.
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(sblox_parts; name)

--- a/src/blox/canonicalmicrocircuit.jl
+++ b/src/blox/canonicalmicrocircuit.jl
@@ -5,8 +5,6 @@ Jansen-Rit model block for canonical micro circuit, analogous to the implementat
 """
 mutable struct JansenRitSPM12 <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
     function JansenRitSPM12(;name, namespace=nothing, τ=1.0, r=2.0/3.0)
@@ -18,7 +16,7 @@ mutable struct JansenRitSPM12 <: NeuralMassBlox
                   D(y) ~ -x/(τ*τ) + jcn/τ]
 
         sys = System(eqs, t, name=name)
-        new(p, sts[1], sts[3], sys, namespace)
+        new(p, sys, namespace)
     end
 end
 

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -299,7 +299,7 @@ function connection_equations(blox_src::AbstractNeuronBlox, blox_dest::AbstractN
     return blox_dest.jcn ~ cr
 end
 
-connection_spike_affects(source, destination) = Tuple{Num, Num}[]
+connection_spike_affects(source, destination, w) = Tuple{Num, Num}[]
 
 function connection_learning_rule(source, destination, w; kwargs...)
     if haskey(kwargs, :learning_rule)
@@ -318,7 +318,7 @@ function Connector(blox_src::AbstractBlox, blox_dest::AbstractBlox; kwargs...)
     lr = connection_learning_rule(blox_src, blox_dest, w; kwargs...)  
     cb = connection_callbacks(blox_src, blox_dest; kwargs...)
 
-    affects_tuple = connection_spike_affects(blox_src, blox_dest)
+    affects_tuple = connection_spike_affects(blox_src, blox_dest, w)
     sa = Dict(namespaced_nameof(blox_src) => to_vector(affects_tuple))  
     
     return Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -445,7 +445,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    x = namespace_expr(blox_src.output, sys_src)
+    x = only(outputs(blox_src))
     r = namespace_expr(blox_src.params[2], sys_src)
 
     eq = sys_dest.jcn ~ sigmoid(x, r)*w
@@ -464,9 +464,8 @@ function Connector(
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
     lr = get_learning_rule(kwargs, nameof(sys_src), nameof(sys_dest))
-
-    if blox_src.output isa Num
-        x = namespace_expr(blox_src.output, sys_src)
+    x = only(outputs(blox_src))
+    if x isa Num
         eq = sys_dest.jcn ~ x*w
 
         return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w, learning_rule=Dict(w => lr))
@@ -476,7 +475,6 @@ function Connector(
         τ_name = Symbol("τ_$(nameof(sys_src))_$(nameof(sys_dest))")
         τ = only(@parameters $(τ_name)=delay)
 
-        x = namespace_expr(blox_src.output, sys_src)
         eq = sys_dest.jcn ~ x(t-τ)*w
 
         return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w, delay=τ, learning_rule=Dict(w => lr))
@@ -493,8 +491,8 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    xₒ = namespace_expr(blox_src.output, sys_src)
-    xᵢ = namespace_expr(blox_dest.output, sys_dest) #needed because this is also the θ term of the block receiving the connection
+    xₒ = only(outputs(blox_src))
+    xᵢ = only(outputs(blox_dest)) #needed because this is also the θ term of the block receiving the connection
 
     eq = sys_dest.jcn ~ w*sin(xₒ - xᵢ)
     
@@ -510,9 +508,9 @@ function Connector(
     sys_src = get_namespaced_sys(blox_src)
     sys_dest = get_namespaced_sys(blox_dest)
 
-    if typeof(blox_src.output) == Num
+    x = only(outputs(blox_src))
+    if x isa Num
         w = generate_weight_param(blox_src, blox_dest; kwargs...)
-        x = namespace_expr(blox_src.output, sys_src, nameof(sys_src))
         eq = sys_dest.jcn ~ x*w
 
         return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -523,13 +521,10 @@ function Connector(
         # Don't accumulate if zero
         τ_name = Symbol("τ_$(nameof(sys_src))_$(nameof(sys_dest))")
         τ = only(@parameters $(τ_name)=delay)
-        push!(bc.delay, τ)
 
         w_name = Symbol("w_$(nameof(sys_src))_$(nameof(sys_dest))")
         w = only(@parameters $(w_name)=weight)
-        push!(bc.weight, w)
-
-        x = namespace_expr(blox_src.output, sys_src, nameof(sys_src))
+        
         eq = sys_dest.jcn ~ x(t-τ)*w
 
         return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w, delay=τ)
@@ -546,7 +541,7 @@ function Connector(
     sys_dest = get_namespaced_sys(blox_dest)
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
-    x = namespace_expr(blox_src.output, sys_src, nameof(sys_src))
+    x = only(outputs(blox_src))
     eq = sys_dest.jcn ~ x*w
 
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -969,9 +964,8 @@ function Connector(
     sys_dest = get_namespaced_sys(blox_dest)
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
-
-    if typeof(blox_src.output) == Num
-        x = namespace_expr(blox_src.output, sys_src)
+    x = only(outputs(blox_src))
+    if x isa Num
         eq = sys_dest.jcn ~ x*w
 
         return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -981,7 +975,6 @@ function Connector(
         τ_name = Symbol("τ_$(nameof(sys_src))_$(nameof(sys_dest))")
         τ = only(@parameters $(τ_name)=delay)
 
-        x = namespace_expr(blox_src.output, sys_src)
         eq = sys_dest.jcn ~ x(t-τ)*w
 
         return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w, delay=τ)
@@ -1090,9 +1083,8 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    s_presyn = namespace_expr(blox_src.output, sys_src)
-    v_postsyn = namespace_expr(blox_dest.voltage, sys_dest)
-    eq = sys_dest.jcn ~ w*(1-sys_dest.κ)*sys_src.gₛ*s_presyn*(sys_dest.eᵣ-v_postsyn)
+    s_presyn = only(outputs(blox_src))
+    eq = sys_dest.jcn ~ w*(1-sys_dest.κ)*sys_src.gₛ*s_presyn*(sys_dest.eᵣ-sys_dest.V)
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
 end
@@ -1107,7 +1099,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    x = namespace_expr(blox_src.output, sys_src)
+    x = only(outputs(blox_src))
     eq = sys_dest.jcn ~ w*x
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -1182,9 +1174,8 @@ function Connector(
 
     V_E = haskey(kwargs, :V_E) ? kwargs[:V_E] : 0.0
 
-    s    = namespace_expr(blox_src.output, sys_src)
-    v_in = namespace_expr(blox_dest.voltage, sys_dest)
-    eq = sys_dest.jcn ~ w*s*(V_E-v_in)
+    s = only(outputs(blox_src))
+    eq = sys_dest.jcn ~ w*s*(V_E - sys_dest.V)
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
 end
@@ -1202,9 +1193,8 @@ function Connector(
 
     V_I = haskey(kwargs, :V_I) ? kwargs[:V_I] : -80.0    
 
-    s    = namespace_expr(blox_src.output, sys_src)
-    v_in = namespace_expr(blox_dest.voltage, sys_dest)
-    eq = sys_dest.jcn ~ w*s*(V_I-v_in)
+    s = only(outputs(blox_src))
+    eq = sys_dest.jcn ~ w*s*(V_I - sys_dest.V)
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
 end

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -1,9 +1,9 @@
 struct Connector
-    source::Vector{Vector{Symbol}}
-    destination::Vector{Vector{Symbol}}
-    equation::Vector{Vector{Equation}}
-    weight::Vector{Vector{Num}}
-    delay::Vector{Vector{Num}}
+    source::Vector{Symbol}
+    destination::Vector{Symbol}
+    equation::Vector{Equation}
+    weight::Vector{Num}
+    delay::Vector{Num}
     discrete_callbacks
     spike_affects::Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}
     learning_rule::Dict{Num, AbstractLearningRule}
@@ -25,65 +25,69 @@ function Connector(
     learning_rule = U <: NoLearningRule ? Dict{Num, NoLearningRule}() : learning_rule
 
     Connector(
-        to_double_vector(src), 
-        to_double_vector(dest), 
-        to_double_vector(equation), 
-        to_double_vector(weight), 
-        to_double_vector(delay), 
-        to_double_vector(discrete_callbacks), 
+        to_vector(src), 
+        to_vector(dest), 
+        to_vector(equation), 
+        to_vector(weight), 
+        to_vector(delay), 
+        to_vector(discrete_callbacks), 
         spike_affects, 
         learning_rule
     )
 end
 
 function Base.isempty(conn::Connector)
-    return all(isempty.(conn.equation)) && all(isempty.(conn.weight)) && all(isempty.(conn.delay)) && all(isempty.(conn.discrete_callbacks)) && isempty(conn.spike_affects) && isempty(conn.learning_rule)
+    return isempty(conn.equation) && isempty(conn.weight) && isempty(conn.delay) && isempty(conn.discrete_callbacks) && isempty(conn.spike_affects) && isempty(conn.learning_rule)
 end
-
-connection_rule(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...)
 
 Base.show(io::IO, c::Connector) = print(io, "$(c.source) => $(c.destination) with ", c.equation)
 
-function string_to_show(v, title)
-    s = string.(v)
-
-    return string("\t $(title): ", "[", join(s, " , "), "]")
+function show_field(v::AbstractVector, title)
+    if !isempty(v)
+        println(title, " :")
+        for val in v
+            println("\t $(val)")
+        end
+    end
 end
 
-function string_to_show(d::Dict, title)
-    s = [string(k, " => ", v) for (k,v) in d]
-
-    return string("\t $(title): ", "[", join(s, " , "), "]")
+function show_field(d::Dict, title)
+    if !isempty(d)
+        println(title, " :")
+        for (k, v) in d
+            println("\t ", k, " => ", v)
+        end
+    end
 end
 
 function Base.show(io::IO, ::MIME"text/plain", c::Connector)
-    N_conns = length(c.source)
     
-    for i in Base.OneTo(N_conns)
-        println("Connection $(c.source[i]) => $(c.destination[i])")
+    println("Connections :")
+    for (s, d) in zip(c.source, c.destination)
+        println("\t $(s) => $(d)")
+    end
 
-        !isempty(c.equation[i]) && println(string_to_show(c.equation[i], "Equation"))
-        !isempty(c.weight[i]) && println(string_to_show(c.weight[i], "Weight"))
-        !isempty(c.delay[i]) && println(string_to_show(c.delay[i], "Delay"))
+    show_field(c.equation, "Equations")
+    show_field(c.weight, "Weights")
+    show_field(c.delay, "Delays")
 
-        d = Dict()
-        for w in c.weight[i]    
-            if haskey(c.learning_rule, w)
-                d[w] = c.learning_rule[w]
+    d = Dict()
+    for w in c.weight  
+        if haskey(c.learning_rule, w)
+            d[w] = c.learning_rule[w]
+        end
+    end
+    show_field(d, "Plasticity model")
+
+    for s in c.source
+        if haskey(c.spike_affects, s)
+            println("$(s) spikes affect :")
+            vars, vals = c.spike_affects[s]
+            for (var, val) in zip(vars, vals)
+                println("\t $(var) += $(val)")
             end
         end
-        !isempty(d) && println(string_to_show(d, "Plasticity model"))
-
-        for s in c.source[i]
-            if haskey(c.spike_affects, s)
-                println("\t $(s) spikes affect :")
-                vars, vals = c.spike_affects[s]
-                for (var, val) in zip(vars, vals)
-                    println("\t \t $(var) += $(val)")
-                end
-            end
-        end
-    end 
+    end
 end
 
 function accumulate_equations!(eqs::AbstractVector{<:Equation}, bloxs)
@@ -108,7 +112,21 @@ function accumulate_equations!(eqs1::Vector{<:Equation}, eqs2::Vector{<:Equation
     return eqs1
 end
 
-ModelingToolkit.equations(c::Connector) = reduce(accumulate_equations!, c.equation)
+function accumulate_equations(eqs1::Vector{<:Equation}, eqs2::Vector{<:Equation})
+    eqs = copy(eqs1)
+    for eq in eqs2
+        lhs = eq.lhs
+        idx = find_eq(eqs1, lhs)
+        
+        if isnothing(idx)
+            push!(eqs, eq)
+        else
+            eqs[idx] = eqs[idx].lhs ~ eqs[idx].rhs + eq.rhs
+        end
+    end
+
+    return eqs
+end
 
 function tuple_append!(t1::Tuple, t2::Tuple)
     append!(first(t1), first(t2))
@@ -117,19 +135,23 @@ function tuple_append!(t1::Tuple, t2::Tuple)
     return t1
 end
 
-discrete_callbacks(c::Connector) = reduce(append!, c.discrete_callbacks)
+ModelingToolkit.equations(c::Connector) = c.equation
 
-sources(c::Connector) = reduce(append!, c.source)
+discrete_callbacks(c::Connector) = c.discrete_callbacks
 
-destinations(c::Connector) = reduce(append!, c.destination)
+sources(c::Connector) = c.source
 
-weights(c::Connector) = reduce(append!, c.weight)
+destinations(c::Connector) = c.destination
 
-delays(c::Connector) = reduce(append!, c.delay)
+weights(c::Connector) = c.weight
+
+delays(c::Connector) = c.delay
 
 spike_affects(c::Connector) = c.spike_affects
 
 learning_rules(c::Connector) = c.learning_rule
+
+learning_rules(conns::AbstractVector{<:Connector}) = mapreduce(c -> c.learning_rule, merge!, conns)
 
 get_equations_with_parameter_lhs(eqs::AbstractVector{<:Equation}) = filter(eq -> isparameter(eq.lhs), eqs)
 
@@ -183,7 +205,7 @@ end
 function Base.merge!(c1::Connector, c2::Connector)
     append!(c1.source, c2.source)
     append!(c1.destination, c2.destination)
-    append!(c1.equation, c2.equation)
+    accumulate_equations!(c1.equation, c2.equation)
     append!(c1.weight, c2.weight)
     append!(c1.delay, c2.delay)
     append!(c1.discrete_callbacks, c2.discrete_callbacks)
@@ -256,13 +278,19 @@ function indegree_constrained_connections(neurons_src, neurons_dst, name_src, na
     return reduce(merge!, C)
 end
 
-function Connector(blox_src::AbstractBlox, blox_dest::AbstractBlox; kwargs...)
+connection_rule(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...)
+
+connection_equation(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...).equation
+
+function connection_equation(blox_src, blox_dest, w) end
+
+function Connector(blox_src, blox_dest::AbstractBlox; kwargs...)
     sys_src = get_namespaced_sys(blox_src)
     sys_dest = get_namespaced_sys(blox_dest)
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    eq = sys_dest.jcn ~ w*sys_src.v
+    eq = connection_equation(blox_src, blox_dest, w)
 
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
 end
@@ -767,7 +795,9 @@ function Connector(
         push!(dc, cb_neuron_init)
     end
 
-    return Connector(namespaced_nameof(blox_src), namespaced_nameof(blox_dest); discrete_callbacks=dc)
+    w = generate_weight_param(blox_src, blox_dest; weight=1)
+
+    return Connector(namespaced_nameof(blox_src), namespaced_nameof(blox_dest); discrete_callbacks=dc, weight=w)
 end
 
 function Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -965,24 +965,6 @@ end
 
 Connector(blox::AbstractBlox, as::AbstractActionSelection; kwargs...) = Connector(namespaced_nameof(blox), namespaced_nameof(as))
 
-# Connects spiking neuron to another spiking neuron
-# None of these neurons have delay yet
-function Connector(
-    blox_src::AbstractNeuronBlox, 
-    blox_dest::AbstractNeuronBlox; 
-    kwargs...
-)
-    sys_src = get_namespaced_sys(blox_src)
-    sys_dest = get_namespaced_sys(blox_dest)
-
-    w = generate_weight_param(blox_src, blox_dest; kwargs...)
-
-    cr = get_connection_rule(kwargs, blox_src, blox_dest, w)
-    eq = sys_dest.jcn ~ cr
-    
-    return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
-end
-
 # Connects a neural mass as a driving input to a spiking neuron
 # Should be used with care because units will be strange (NMM typically outputs voltage but neuron inputs are typically currents)
 function Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -5,7 +5,7 @@ struct Connector
     weight::Vector{Num}
     delay::Vector{Num}
     discrete_callbacks
-    spike_affects::Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}
+    spike_affects::Dict{Symbol, Vector{Tuple{Num, Num}}}
     learning_rule::Dict{Num, AbstractLearningRule}
 end
 
@@ -16,7 +16,7 @@ function Connector(
     weight=Num[], 
     delay=Num[], 
     discrete_callbacks=[], 
-    spike_affects=Dict{Symbol, Tuple{Vector{Num}, Vector{Num}}}(),
+    spike_affects=Dict{Symbol, Vector{Tuple{Num, Num}}}(),
     learning_rule=Dict{Num, AbstractLearningRule}()
     )
 
@@ -82,8 +82,8 @@ function Base.show(io::IO, ::MIME"text/plain", c::Connector)
     for s in c.source
         if haskey(c.spike_affects, s)
             println("$(s) spikes affect :")
-            vars, vals = c.spike_affects[s]
-            for (var, val) in zip(vars, vals)
+            v = c.spike_affects[s]
+            for (var, val) in v
                 println("\t $(var) += $(val)")
             end
         end
@@ -126,13 +126,6 @@ function accumulate_equations(eqs1::Vector{<:Equation}, eqs2::Vector{<:Equation}
     end
 
     return eqs
-end
-
-function tuple_append!(t1::Tuple, t2::Tuple)
-    append!(first(t1), first(t2))
-    append!(last(t1), last(t2))
-
-    return t1
 end
 
 ModelingToolkit.equations(c::Connector) = c.equation
@@ -225,7 +218,7 @@ function Base.merge!(c1::Connector, c2::Connector)
     append!(c1.weight, c2.weight)
     append!(c1.delay, c2.delay)
     append!(c1.discrete_callbacks, c2.discrete_callbacks)
-    mergewith!(tuple_append!, c1.spike_affects, c2.spike_affects)
+    mergewith!(append!, c1.spike_affects, c2.spike_affects)
     merge!(c1.learning_rule, c2.learning_rule)
 
     return c1
@@ -472,7 +465,7 @@ function Connector(
 
     lr = get_learning_rule(kwargs, nameof(sys_src), nameof(sys_dest))
 
-    if typeof(blox_src.output) == Num
+    if blox_src.output isa Num
         x = namespace_expr(blox_src.output, sys_src)
         eq = sys_dest.jcn ~ x*w
 
@@ -1011,9 +1004,9 @@ function Connector(
     # Compare the unique namespaced names of both systems
     sa = if nameof(sys_src) == nameof(sys_dest)
         # x is the rise variable for NMDA synapses and it only applies to self-recurrent connections
-        nameof(sys_src) => ([sys_dest.S_AMPA, sys_dest.x], [w, w])
+        nameof(sys_src) => [(sys_dest.S_AMPA, w), (sys_dest.x, w)]
     else
-        nameof(sys_src) => ([sys_dest.S_AMPA], [w])
+        nameof(sys_src) => [(sys_dest.S_AMPA, w)]
     end
 
     return Connector(nameof(sys_src), nameof(sys_dest); equation = eq, weight = [w], spike_affects = Dict(sa))
@@ -1029,7 +1022,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    sa = nameof(sys_src) => ([sys_dest.S_GABA], [w])
+    sa = nameof(sys_src) => [(sys_dest.S_GABA, w)]
 
     return Connector(nameof(sys_src), nameof(sys_dest); weight = w, spike_affects = Dict(sa))
 end

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -157,6 +157,22 @@ get_equations_with_parameter_lhs(eqs::AbstractVector{<:Equation}) = filter(eq ->
 
 get_equations_with_state_lhs(eqs::AbstractVector{<:Equation}) = filter(eq -> !isparameter(eq.lhs), eqs)
 
+function get_states_spikes_affect(sa, name) 
+    if haskey(sa, name)
+        return first.(sa[name])
+    else
+        Num[]
+    end
+end
+
+function get_params_spikes_affect(sa, name) 
+    if haskey(sa, name)
+        return last.(sa[name])
+    else
+        Num[]
+    end
+end
+
 function generate_weight_param(blox_out, blox_in; kwargs...)
     name_out = namespaced_nameof(blox_out)
     name_in = namespaced_nameof(blox_in)

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -280,19 +280,47 @@ end
 
 connection_rule(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...)
 
-connection_equation(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...).equation
+connection_equations(blox_src, blox_dest; kwargs...) = Connector(blox_src, blox_dest; kwargs...).equation
 
-function connection_equation(blox_src, blox_dest, w) end
+connection_equations(source, destination, w; kwargs...) = Equation[]
 
-function Connector(blox_src, blox_dest::AbstractBlox; kwargs...)
-    sys_src = get_namespaced_sys(blox_src)
-    sys_dest = get_namespaced_sys(blox_dest)
+function connection_equations(blox_src::AbstractNeuronBlox, blox_dest::AbstractNeuronBlox, w; kwargs...)
+    cr = get_connection_rule(kwargs, blox_src, blox_dest, w)
 
+    return sys_dest.jcn ~ cr
+end
+
+connection_spike_affects(source, destination) = Tuple{Num, Num}[]
+
+function connection_learning_rule(source, destination, w; kwargs...)
+    if haskey(kwargs, :learning_rule)
+        return Dict(w => deepcopy(kwargs[:learning_rule]))
+    else
+        return Dict{Num, AbstractLearningRule}()
+    end
+end
+    
+connection_callbacks(source, destination; kwargs...) = []
+
+function Connector(blox_src::AbstractBlox, blox_dest::AbstractBlox; kwargs...)
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    eq = connection_equation(blox_src, blox_dest, w)
+    eq = connection_equations(blox_src, blox_dest, w; kwargs...)
+    lr = connection_learning_rule(blox_src, blox_dest, w; kwargs...)  
+    cb = connection_callbacks(blox_src, blox_dest; kwargs...)
 
-    return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
+    affects_tuple = connection_spike_affects(blox_src, blox_dest)
+    sa = Dict(namespaced_nameof(blox_src) => to_vector(affects_tuple))  
+    
+    return Connector(
+        namespaced_nameof(blox_src), 
+        namespaced_nameof(blox_dest); 
+        equation = eq, 
+        weight = w,
+        spike_affects = sa,
+        discrete_callbacks = cb,
+        learning_rule = lr
+    )
 end
 
 function Connector(

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -296,7 +296,7 @@ connection_equations(source, destination, w; kwargs...) = Equation[]
 function connection_equations(blox_src::AbstractNeuronBlox, blox_dest::AbstractNeuronBlox, w; kwargs...)
     cr = get_connection_rule(kwargs, blox_src, blox_dest, w)
 
-    return sys_dest.jcn ~ cr
+    return blox_dest.jcn ~ cr
 end
 
 connection_spike_affects(source, destination) = Tuple{Num, Num}[]

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -445,7 +445,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    x = only(outputs(blox_src))
+    x = only(outputs(blox_src; namespaced=true))
     r = namespace_expr(blox_src.params[2], sys_src)
 
     eq = sys_dest.jcn ~ sigmoid(x, r)*w
@@ -464,7 +464,7 @@ function Connector(
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
     lr = get_learning_rule(kwargs, nameof(sys_src), nameof(sys_dest))
-    x = only(outputs(blox_src))
+    x = only(outputs(blox_src; namespaced=true))
     if x isa Num
         eq = sys_dest.jcn ~ x*w
 
@@ -491,8 +491,8 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    xₒ = only(outputs(blox_src))
-    xᵢ = only(outputs(blox_dest)) #needed because this is also the θ term of the block receiving the connection
+    xₒ = only(outputs(blox_src; namespaced=true))
+    xᵢ = only(outputs(blox_dest; namespaced=true)) #needed because this is also the θ term of the block receiving the connection
 
     eq = sys_dest.jcn ~ w*sin(xₒ - xᵢ)
     
@@ -508,7 +508,7 @@ function Connector(
     sys_src = get_namespaced_sys(blox_src)
     sys_dest = get_namespaced_sys(blox_dest)
 
-    x = only(outputs(blox_src))
+    x = only(outputs(blox_src; namespaced=true))
     if x isa Num
         w = generate_weight_param(blox_src, blox_dest; kwargs...)
         eq = sys_dest.jcn ~ x*w
@@ -541,7 +541,7 @@ function Connector(
     sys_dest = get_namespaced_sys(blox_dest)
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
-    x = only(outputs(blox_src))
+    x = only(outputs(blox_src; namespaced=true))
     eq = sys_dest.jcn ~ x*w
 
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -964,7 +964,7 @@ function Connector(
     sys_dest = get_namespaced_sys(blox_dest)
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
-    x = only(outputs(blox_src))
+    x = only(outputs(blox_src; namespaced=true))
     if x isa Num
         eq = sys_dest.jcn ~ x*w
 
@@ -1083,7 +1083,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    s_presyn = only(outputs(blox_src))
+    s_presyn = only(outputs(blox_src; namespaced=true))
     eq = sys_dest.jcn ~ w*(1-sys_dest.κ)*sys_src.gₛ*s_presyn*(sys_dest.eᵣ-sys_dest.V)
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -1099,7 +1099,7 @@ function Connector(
 
     w = generate_weight_param(blox_src, blox_dest; kwargs...)
 
-    x = only(outputs(blox_src))
+    x = only(outputs(blox_src; namespaced=true))
     eq = sys_dest.jcn ~ w*x
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -1174,7 +1174,7 @@ function Connector(
 
     V_E = haskey(kwargs, :V_E) ? kwargs[:V_E] : 0.0
 
-    s = only(outputs(blox_src))
+    s = only(outputs(blox_src; namespaced=true))
     eq = sys_dest.jcn ~ w*s*(V_E - sys_dest.V)
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)
@@ -1193,7 +1193,7 @@ function Connector(
 
     V_I = haskey(kwargs, :V_I) ? kwargs[:V_I] : -80.0    
 
-    s = only(outputs(blox_src))
+    s = only(outputs(blox_src; namespaced=true))
     eq = sys_dest.jcn ~ w*s*(V_I - sys_dest.V)
     
     return Connector(nameof(sys_src), nameof(sys_dest); equation=eq, weight=w)

--- a/src/blox/cortical.jl
+++ b/src/blox/cortical.jl
@@ -1,7 +1,7 @@
 struct CorticalBlox <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     kwargs
 
@@ -86,7 +86,7 @@ end
 struct LIFExciCircuitBlox <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     kwargs
 
@@ -168,7 +168,7 @@ end
 struct LIFInhCircuitBlox <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     kwargs
 

--- a/src/blox/cortical.jl
+++ b/src/blox/cortical.jl
@@ -71,7 +71,7 @@ struct CorticalBlox <: CompositeBlox
             add_edge!(g, N_wta+1, i, Dict(:weight => 1))
         end
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         # If a namespace is not provided, assume that this is the highest level
         # and construct the ODEsystem from the graph.
         # If there is a higher namespace, construct only a subsystem containing the parts of this level
@@ -154,7 +154,7 @@ struct LIFExciCircuitBlox <: CompositeBlox
             end
         end
 
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
 
         if skip_system_creation
             sys = nothing
@@ -232,7 +232,7 @@ struct LIFInhCircuitBlox <: CompositeBlox
             end
         end
 
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
 
         if skip_system_creation
             sys = nothing

--- a/src/blox/discrete.jl
+++ b/src/blox/discrete.jl
@@ -3,7 +3,7 @@ abstract type AbstractDiscrete <: AbstractBlox end
 abstract type AbstractModulator <: AbstractDiscrete end
 
 struct Matrisome <: AbstractDiscrete
-    odesystem
+    system
     namespace
     t_event
     function Matrisome(; name, namespace=nothing, t_event=180.0)
@@ -33,7 +33,7 @@ end
 
 
 struct Striosome <: AbstractDiscrete
-    odesystem
+    system
     namespace
 
     function Striosome(; name, namespace=nothing)
@@ -54,7 +54,7 @@ struct Striosome <: AbstractDiscrete
 end
 
 struct TAN <: AbstractDiscrete
-    odesystem
+    system
     namespace
 
     function TAN(; name, namespace=nothing, κ=100, λ=1)
@@ -70,7 +70,7 @@ struct TAN <: AbstractDiscrete
 end
 
 struct SNc <: AbstractModulator
-    odesystem
+    system
     N_time_blocks
     κ_DA
     DA_reward

--- a/src/blox/neural_mass.jl
+++ b/src/blox/neural_mass.jl
@@ -6,7 +6,7 @@ mutable struct NextGenerationBlox <: NeuralMassBlox
     alpha_inv::Num
     k::Num
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     namespace
     function NextGenerationBlox(;name,namespace=nothing, C=30.0, Δ=1.0, η_0=5.0, v_syn=-10.0, alpha_inv=35.0, k=0.105)
         params = @parameters C=C Δ=Δ η_0=η_0 v_syn=v_syn alpha_inv=alpha_inv k=k
@@ -29,7 +29,7 @@ mutable struct NextGenerationResolvedBlox <: NeuralMassBlox
     alpha_inv::Num
     k::Num
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     namespace
     function NextGenerationResolvedBlox(;name,namespace=nothing, C=30.0, Δ=1.0, η_0=5.0, v_syn=-10.0, alpha_inv=35.0, k=0.105)
         params = @parameters C=C Δ=Δ η_0=η_0 v_syn=v_syn alpha_inv=alpha_inv k=k
@@ -50,7 +50,7 @@ mutable struct NextGenerationEIBlox <: NeuralMassBlox
     Cₑ::Num
     Cᵢ::Num
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     namespace
     function NextGenerationEIBlox(;name,namespace=nothing, Cₑ=30.0,Cᵢ=30.0, Δₑ=0.5, Δᵢ=0.5, η_0ₑ=10.0, η_0ᵢ=0.0, v_synₑₑ=10.0, v_synₑᵢ=-10.0, v_synᵢₑ=10.0, v_synᵢᵢ=-10.0, alpha_invₑₑ=10.0, alpha_invₑᵢ=0.8, alpha_invᵢₑ=10.0, alpha_invᵢᵢ=0.8, kₑₑ=0, kₑᵢ=0.5, kᵢₑ=0.65, kᵢᵢ=0)
         params = @parameters Cₑ=Cₑ Cᵢ=Cᵢ Δₑ=Δₑ Δᵢ=Δᵢ η_0ₑ=η_0ₑ η_0ᵢ=η_0ᵢ v_synₑₑ=v_synₑₑ v_synₑᵢ=v_synₑᵢ v_synᵢₑ=v_synᵢₑ v_synᵢᵢ=v_synᵢᵢ alpha_invₑₑ=alpha_invₑₑ alpha_invₑᵢ=alpha_invₑᵢ alpha_invᵢₑ=alpha_invᵢₑ alpha_invᵢᵢ=alpha_invᵢᵢ kₑₑ=kₑₑ kₑᵢ=kₑᵢ kᵢₑ=kᵢₑ kᵢᵢ=kᵢᵢ
@@ -96,7 +96,7 @@ Arguments:
 """
 
 struct LinearNeuralMass <: NeuralMassBlox
-    odesystem
+    system
     namespace
 
     function LinearNeuralMass(;name, namespace=nothing)
@@ -130,7 +130,7 @@ Arguments:
 """
 struct HarmonicOscillator <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function HarmonicOscillator(;name, namespace=nothing, ω=25*(2*pi)*0.001, ζ=1.0, k=625*(2*pi), h=35.0)
@@ -176,7 +176,7 @@ Citations:
 """
 struct JansenRit <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
     function JansenRit(;name,
                         namespace=nothing,
@@ -238,7 +238,7 @@ Arguments:
 """
 struct WilsonCowan <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function WilsonCowan(;name,
@@ -286,7 +286,7 @@ Citations:
 """
 struct LarterBreakspear <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function LarterBreakspear(;
@@ -392,7 +392,7 @@ inhibitory neurons. PLoS Computational Biology, 4(11), 2008).
 """
 struct Generic2dOscillator <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function Generic2dOscillator(;
@@ -466,7 +466,7 @@ Citations:
 """
 struct KuramotoOscillator <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function KuramotoOscillator(;
@@ -496,7 +496,7 @@ end
 
 struct PYR_Izh <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function PYR_Izh(;
@@ -530,7 +530,7 @@ end
 
 struct QIF_PING_NGNMM <: NeuralMassBlox
     params
-    odesystem
+    system
     namespace
 
     function QIF_PING_NGNMM(;

--- a/src/blox/neural_mass.jl
+++ b/src/blox/neural_mass.jl
@@ -517,9 +517,9 @@ struct PYR_Izh <: NeuralMassBlox
                 ω=0.0)
             p = paramscoping(Δ=Δ, α=α, gₛ=gₛ, η̄=η̄, I_ext=I_ext, eᵣ=eᵣ, a=a, b=b, wⱼ=wⱼ, sⱼ=sⱼ, κ=κ)
             Δ, α, gₛ, η̄, I_ext, eᵣ, a, b, wⱼ, sⱼ, κ = p
-            sts = @variables r(t)=0.0 v(t)=0.0 w(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
+            sts = @variables r(t)=0.0 V(t)=0.0 w(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
             eqs = [ D(r) ~ Δ/π + 2*r*v - (α+gₛ*s)*r,
-                    D(v) ~ v^2 - α*v - w + η̄ + I_ext*sin(ω*t) + gₛ*s*κ*(eᵣ - v) + jcn - (π*r)^2,
+                    D(V) ~ v^2 - α*v - w + η̄ + I_ext*sin(ω*t) + gₛ*s*κ*(eᵣ - v) + jcn - (π*r)^2,
                     D(w) ~ a*(b*v - w) + wⱼ*r,
                     D(s) ~ -s/τₛ + sⱼ*r
                 ]
@@ -545,10 +545,10 @@ struct QIF_PING_NGNMM <: NeuralMassBlox
                             A=0.0)
         p = paramscoping(Δ=Δ, τₘ=τₘ, H=H, I_ext=I_ext, J_internal=J_internal)
         Δ, τₘ, H, I_ext, J_internal = p
-        sts = @variables r(t)=0.0 [output=true] v(t)=0.0 jcn(t) [input=true]
+        sts = @variables r(t)=0.0 [output=true] V(t)=0.0 jcn(t) [input=true]
         @brownian ξ
         eqs = [D(r) ~ Δ/(π*τₘ^2) + 2*r*v/τₘ,
-               D(v) ~ (v^2 + H + I_ext*sin(ω*t))/τₘ - τₘ*(π*r)^2 + J_internal*r  + A*ξ + jcn]
+               D(V) ~ (v^2 + H + I_ext*sin(ω*t))/τₘ - τₘ*(π*r)^2 + J_internal*r  + A*ξ + jcn]
         sys = System(eqs, t, sts, p; name=name)
 
         new(p, sys, namespace)

--- a/src/blox/neural_mass.jl
+++ b/src/blox/neural_mass.jl
@@ -518,9 +518,9 @@ struct PYR_Izh <: NeuralMassBlox
             p = paramscoping(Δ=Δ, α=α, gₛ=gₛ, η̄=η̄, I_ext=I_ext, eᵣ=eᵣ, a=a, b=b, wⱼ=wⱼ, sⱼ=sⱼ, κ=κ)
             Δ, α, gₛ, η̄, I_ext, eᵣ, a, b, wⱼ, sⱼ, κ = p
             sts = @variables r(t)=0.0 V(t)=0.0 w(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
-            eqs = [ D(r) ~ Δ/π + 2*r*v - (α+gₛ*s)*r,
-                    D(V) ~ v^2 - α*v - w + η̄ + I_ext*sin(ω*t) + gₛ*s*κ*(eᵣ - v) + jcn - (π*r)^2,
-                    D(w) ~ a*(b*v - w) + wⱼ*r,
+            eqs = [ D(r) ~ Δ/π + 2*r*V - (α+gₛ*s)*r,
+                    D(V) ~ v^2 - α*V - w + η̄ + I_ext*sin(ω*t) + gₛ*s*κ*(eᵣ - V) + jcn - (π*r)^2,
+                    D(w) ~ a*(b*V - w) + wⱼ*r,
                     D(s) ~ -s/τₛ + sⱼ*r
                 ]
             sys = System(eqs, t, sts, p; name=name)
@@ -547,8 +547,8 @@ struct QIF_PING_NGNMM <: NeuralMassBlox
         Δ, τₘ, H, I_ext, J_internal = p
         sts = @variables r(t)=0.0 [output=true] V(t)=0.0 jcn(t) [input=true]
         @brownian ξ
-        eqs = [D(r) ~ Δ/(π*τₘ^2) + 2*r*v/τₘ,
-               D(V) ~ (v^2 + H + I_ext*sin(ω*t))/τₘ - τₘ*(π*r)^2 + J_internal*r  + A*ξ + jcn]
+        eqs = [D(r) ~ Δ/(π*τₘ^2) + 2*r*V/τₘ,
+               D(V) ~ (V^2 + H + I_ext*sin(ω*t))/τₘ - τₘ*(π*r)^2 + J_internal*r  + A*ξ + jcn]
         sys = System(eqs, t, sts, p; name=name)
 
         new(p, sys, namespace)

--- a/src/blox/neural_mass.jl
+++ b/src/blox/neural_mass.jl
@@ -519,7 +519,7 @@ struct PYR_Izh <: NeuralMassBlox
             Δ, α, gₛ, η̄, I_ext, eᵣ, a, b, wⱼ, sⱼ, κ = p
             sts = @variables r(t)=0.0 V(t)=0.0 w(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
             eqs = [ D(r) ~ Δ/π + 2*r*V - (α+gₛ*s)*r,
-                    D(V) ~ v^2 - α*V - w + η̄ + I_ext*sin(ω*t) + gₛ*s*κ*(eᵣ - V) + jcn - (π*r)^2,
+                    D(V) ~ V^2 - α*V - w + η̄ + I_ext*sin(ω*t) + gₛ*s*κ*(eᵣ - V) + jcn - (π*r)^2,
                     D(w) ~ a*(b*V - w) + wⱼ*r,
                     D(s) ~ -s/τₛ + sⱼ*r
                 ]

--- a/src/blox/neural_mass.jl
+++ b/src/blox/neural_mass.jl
@@ -5,7 +5,6 @@ mutable struct NextGenerationBlox <: NeuralMassBlox
     v_syn::Num
     alpha_inv::Num
     k::Num
-    output
     connector::Num
     odesystem::ODESystem
     namespace
@@ -18,7 +17,7 @@ mutable struct NextGenerationBlox <: NeuralMassBlox
         eqs = [Equation(D(Z), (1/C)*(-im*((Z-1)^2)/2 + (((Z+1)^2)/2)*(-Δ + im*(η_0) + im*v_syn*g) - ((Z^2-1)/2)*g))
                     D(g) ~ alpha_inv*((k/(C*pi))*(1-abs(Z)^2)/(1+Z+conj(Z)+abs(Z)^2) - g)]
         odesys = ODESystem(eqs, t, sts, params; name=name)
-        new(C, Δ, η_0, v_syn, alpha_inv, k, sts[1], odesys.Z, odesys, namespace)
+        new(C, Δ, η_0, v_syn, alpha_inv, k, odesys.Z, odesys, namespace)
     end
 end
 
@@ -29,13 +28,12 @@ mutable struct NextGenerationResolvedBlox <: NeuralMassBlox
     v_syn::Num
     alpha_inv::Num
     k::Num
-    output
     connector::Num
     odesystem::ODESystem
     namespace
     function NextGenerationResolvedBlox(;name,namespace=nothing, C=30.0, Δ=1.0, η_0=5.0, v_syn=-10.0, alpha_inv=35.0, k=0.105)
         params = @parameters C=C Δ=Δ η_0=η_0 v_syn=v_syn alpha_inv=alpha_inv k=k
-        sts    = @variables a(t)=0.5 [output=true] b(t)=0.0 [output=true] g(t)=1.6
+        sts    = @variables a(t)=0.5 [output=true] b(t)=0.0 g(t)=1.6
         #Z = a + ib
         
         eqs = [ D(a) ~ (1/C)*(b*(a-1) - (Δ/2)*((a+1)^2-b^2) - η_0*b*(a+1) - v_syn*g*b*(a+1) - (g/2)*(a^2-b^2-1)),
@@ -43,7 +41,7 @@ mutable struct NextGenerationResolvedBlox <: NeuralMassBlox
                 D(g) ~ alpha_inv*((k/(C*pi))*((1-a^2-b^2)/(1+2*a+a^2+b^2)) - g)
                ]
         odesys = ODESystem(eqs, t, sts, params; name=name)
-        new(C, Δ, η_0, v_syn, alpha_inv, k, sts[1], odesys.a, odesys, namespace)
+        new(C, Δ, η_0, v_syn, alpha_inv, k, odesys.a, odesys, namespace)
     end
 end
 
@@ -51,13 +49,12 @@ end
 mutable struct NextGenerationEIBlox <: NeuralMassBlox
     Cₑ::Num
     Cᵢ::Num
-    output
     connector::Num
     odesystem::ODESystem
     namespace
     function NextGenerationEIBlox(;name,namespace=nothing, Cₑ=30.0,Cᵢ=30.0, Δₑ=0.5, Δᵢ=0.5, η_0ₑ=10.0, η_0ᵢ=0.0, v_synₑₑ=10.0, v_synₑᵢ=-10.0, v_synᵢₑ=10.0, v_synᵢᵢ=-10.0, alpha_invₑₑ=10.0, alpha_invₑᵢ=0.8, alpha_invᵢₑ=10.0, alpha_invᵢᵢ=0.8, kₑₑ=0, kₑᵢ=0.5, kᵢₑ=0.65, kᵢᵢ=0)
         params = @parameters Cₑ=Cₑ Cᵢ=Cᵢ Δₑ=Δₑ Δᵢ=Δᵢ η_0ₑ=η_0ₑ η_0ᵢ=η_0ᵢ v_synₑₑ=v_synₑₑ v_synₑᵢ=v_synₑᵢ v_synᵢₑ=v_synᵢₑ v_synᵢᵢ=v_synᵢᵢ alpha_invₑₑ=alpha_invₑₑ alpha_invₑᵢ=alpha_invₑᵢ alpha_invᵢₑ=alpha_invᵢₑ alpha_invᵢᵢ=alpha_invᵢᵢ kₑₑ=kₑₑ kₑᵢ=kₑᵢ kᵢₑ=kᵢₑ kᵢᵢ=kᵢᵢ
-        sts    = @variables aₑ(t)=-0.6 [output=true] bₑ(t)=0.18 [output=true] aᵢ(t)=0.02 [output=true] bᵢ(t)=0.21 [output=true] gₑₑ(t)=0 gₑᵢ(t)=0.23 gᵢₑ(t)=0.26 gᵢᵢ(t)=0
+        sts    = @variables aₑ(t)=-0.6 [output=true] bₑ(t)=0.18 aᵢ(t)=0.02 bᵢ(t)=0.21 gₑₑ(t)=0 gₑᵢ(t)=0.23 gᵢₑ(t)=0.26 gᵢᵢ(t)=0
         
         #Z = a + ib
         
@@ -71,7 +68,7 @@ mutable struct NextGenerationEIBlox <: NeuralMassBlox
                 D(gᵢᵢ) ~ alpha_invᵢᵢ*((kᵢᵢ/(Cᵢ*pi))*((1-aᵢ^2-bᵢ^2)/(1+2*aᵢ+aᵢ^2+bᵢ^2)) - gᵢᵢ)
                ]
         odesys = ODESystem(eqs, t, sts, params; name=name)
-        new(Cₑ, Cᵢ, sts[1], odesys.aₑ, odesys, namespace)
+        new(Cₑ, Cᵢ, odesys.aₑ, odesys, namespace)
     end
 end
 # this assignment is temporary until all the code is changed to the new name
@@ -99,15 +96,14 @@ Arguments:
 """
 
 struct LinearNeuralMass <: NeuralMassBlox
-    output
-    jcn
     odesystem
     namespace
+
     function LinearNeuralMass(;name, namespace=nothing)
         sts = @variables x(t)=0.0 [output=true] jcn(t) [input=true]
         eqs = [D(x) ~ jcn]
         sys = System(eqs, t, name=name)
-        new(sts[1], sts[2], sys, namespace)
+        new(sys, namespace)
     end
 end
 
@@ -134,10 +130,9 @@ Arguments:
 """
 struct HarmonicOscillator <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
+
     function HarmonicOscillator(;name, namespace=nothing, ω=25*(2*pi)*0.001, ζ=1.0, k=625*(2*pi), h=35.0)
         # p = progress_scope(ω, ζ, k, h)
         p = paramscoping(ω=ω, ζ=ζ, k=k, h=h)
@@ -146,7 +141,8 @@ struct HarmonicOscillator <: NeuralMassBlox
         eqs    = [D(x) ~ y-(2*ω*ζ*x)+ k*(2/π)*(atan((jcn)/h))
                   D(y) ~ -(ω^2)*x]
         sys = System(eqs, t, name=name)
-        new(p, sts[1], sts[3], sys, namespace)
+
+        new(p, sys, namespace)
     end
 end
 
@@ -180,8 +176,6 @@ Citations:
 """
 struct JansenRit <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
     function JansenRit(;name,
@@ -208,7 +202,7 @@ struct JansenRit <: NeuralMassBlox
             sys = System(eqs, t, name=name)
             #can't use outputs because x(t) is Num by then
             #wrote inputs similarly to keep consistent
-            return new(p, sts[1], sts[3], sys, namespace)
+            return new(p, sys, namespace)
         else
             sts = @variables x(..)=1.0 [output=true] y(t)=1.0 jcn(t) [input=true] 
             eqs = [D(x(t)) ~ y - ((2/τ)*x(t)),
@@ -216,7 +210,7 @@ struct JansenRit <: NeuralMassBlox
             sys = System(eqs, t, name=name)
             #can't use outputs because x(t) is Num by then
             #wrote inputs similarly to keep consistent
-            return new(p, sts[1], sts[3], sys, namespace)
+            return new(p, sys, namespace)
         end
         sys = System(eqs, t, name=name)
         #can't use outputs because x(t) is Num by then
@@ -244,10 +238,9 @@ Arguments:
 """
 struct WilsonCowan <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
+
     function WilsonCowan(;name,
                         namespace=nothing,
                         τ_E=1.0,
@@ -269,7 +262,8 @@ struct WilsonCowan <: NeuralMassBlox
         eqs = [D(E) ~ -E/τ_E + 1/(1 + exp(-a_E*(c_EE*E - c_IE*I - θ_E + η*(jcn)))), #old form: D(E) ~ -E/τ_E + 1/(1 + exp(-a_E*(c_EE*E - c_IE*I - θ_E + P + η*(jcn)))),
                D(I) ~ -I/τ_I + 1/(1 + exp(-a_I*(c_EI*E - c_II*I - θ_I)))]
         sys = System(eqs, t, name=name)
-        new(p, sts[1], sts[3], sys, namespace)
+
+        new(p, sys, namespace)
     end
 end
 
@@ -292,10 +286,9 @@ Citations:
 """
 struct LarterBreakspear <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
+
     function LarterBreakspear(;
                         name,
                         namespace=nothing,
@@ -348,7 +341,7 @@ struct LarterBreakspear <: NeuralMassBlox
                 m_Na ~  0.5*(1 + tanh((V-T_Na)/δ_Na)),
                 m_K ~  0.5*(1 + tanh((V-T_K)/δ_K))]
         sys = System(eqs, t; name=name)
-        new(p, sts[5], sts[4], sys, namespace)
+        new(p, sys, namespace)
     end
 end
 
@@ -399,10 +392,9 @@ inhibitory neurons. PLoS Computational Biology, 4(11), 2008).
 """
 struct Generic2dOscillator <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
+
     function Generic2dOscillator(;
                         name,
                         namespace=nothing,
@@ -427,7 +419,7 @@ struct Generic2dOscillator <: NeuralMassBlox
         eqs = [ D(V) ~ d * τ * ( -f * V^3 + e * V^2 + g * V + α * W - γ * jcn) + bn * w,
                 D(W) ~ d / τ * ( c * V^2 + b * V - β * W + a) + bn * v]
         sys = System(eqs, t, sts, p; name=name)
-        new(p, sts[1], sts[3], sys, namespace)
+        new(p, sys, namespace)
     end
 end
 
@@ -474,10 +466,9 @@ Citations:
 """
 struct KuramotoOscillator <: NeuralMassBlox
     params
-    output
-    jcn
     odesystem
     namespace
+
     function KuramotoOscillator(;
                         name,
                         namespace=nothing,
@@ -493,23 +484,21 @@ struct KuramotoOscillator <: NeuralMassBlox
             @brownian w
             eqs = [D(θ) ~ ω + ζ * w + jcn]
             sys = System(eqs, t, sts, p; name=name)
-            new(p, sts[1], sts[2], sys, namespace)
+            new(p, sys, namespace)
         else
             sts = @variables θ(t)=0.0 [output = true] jcn(t) [input=true]
             eqs = [D(θ) ~ ω + jcn]
             sys = System(eqs, t, sts, p; name=name)
-            new(p, sts[1], sts[2], sys, namespace)
+            new(p, sys, namespace)
         end
     end
 end
 
 struct PYR_Izh <: NeuralMassBlox
     params
-    output
-    voltage
-    jcn
     odesystem
     namespace
+
     function PYR_Izh(;
                 name,
                 namespace=nothing,
@@ -535,17 +524,15 @@ struct PYR_Izh <: NeuralMassBlox
                     D(s) ~ -s/τₛ + sⱼ*r
                 ]
             sys = System(eqs, t, sts, p; name=name)
-            new(p, sts[4], sts[2], sts[5], sys, namespace)
+            new(p, sys, namespace)
     end
 end
 
 struct QIF_PING_NGNMM <: NeuralMassBlox
     params
-    output
-    voltage
-    jcn
     odesystem
     namespace
+
     function QIF_PING_NGNMM(;
                             name,
                             namespace=nothing,
@@ -563,6 +550,7 @@ struct QIF_PING_NGNMM <: NeuralMassBlox
         eqs = [D(r) ~ Δ/(π*τₘ^2) + 2*r*v/τₘ,
                D(v) ~ (v^2 + H + I_ext*sin(ω*t))/τₘ - τₘ*(π*r)^2 + J_internal*r  + A*ξ + jcn]
         sys = System(eqs, t, sts, p; name=name)
-        new(p, sts[1], sts[2], sts[3], sys, namespace)
+
+        new(p, sys, namespace)
     end
 end

--- a/src/blox/neuron_models.jl
+++ b/src/blox/neuron_models.jl
@@ -3,7 +3,6 @@ abstract type AbstractExciNeuronBlox <: AbstractNeuronBlox end
 
 struct HHNeuronExciBlox <: AbstractExciNeuronBlox
     odesystem
-    output
     namespace
 
 	function HHNeuronExciBlox(;
@@ -28,6 +27,7 @@ struct HHNeuronExciBlox <: AbstractExciNeuronBlox
 			I_asc(t)
 			[input=true]
 			G(t)=0.0 
+            [output=true]
 			z(t)=0.0
 			Gₛₜₚ(t)=0.0 
             spikes_cumulative(t)=0.0
@@ -84,7 +84,7 @@ struct HHNeuronExciBlox <: AbstractExciNeuronBlox
 			name = Symbol(name)
 			)
 
-		new(sys, spikes, namespace)
+		new(sys, namespace)
 	end
 end	
 
@@ -113,7 +113,7 @@ struct HHNeuronInhibBlox <: AbstractInhNeuronBlox
 			I_in(t)
 			[input=true]
             G(t)=0.0 
-			[output = true] 
+			[output=true] 
 			z(t)=0.0
             spikes_cumulative(t)=0.0
             spikes_window(t)=0.0
@@ -199,7 +199,7 @@ struct HHNeuronInhib_MSN_Adam_Blox <: AbstractInhNeuronBlox
 			I_asc(t)
 			[input=true]
 			G(t)=0.0 
-			[output = true] 
+			[output =true] 
 		end
 
 		ps = @parameters begin 
@@ -289,9 +289,9 @@ struct HHNeuronInhib_FSI_Adam_Blox <: AbstractInhNeuronBlox
 			I_asc(t)
 			[input=true]
 			G(t)=0.0 
-			[output = true] 
+			[output=true] 
 			Gₛ(t)=0.0 
-			[output = true] 
+			[output=true] 
 		end
 
 		ps = @parameters begin 
@@ -540,12 +540,10 @@ References:
 # I_in = [-2.5, 2.5] μA
 # Remember: synaptic weights need to be in μA/mV, so they're very small!
 struct IFNeuron <: AbstractNeuronBlox
-	params
-    output
-    jcn
-	voltage
+    params
     odesystem
     namespace
+
 	function IFNeuron(;name,
 					   namespace=nothing, 
 					   C=1.0,
@@ -554,11 +552,12 @@ struct IFNeuron <: AbstractNeuronBlox
 					   I_in=0)
 		p = paramscoping(C=C, θ=θ, Eₘ=Eₘ, I_in=I_in)
 		C, θ, Eₘ, I_in = p
-		sts = @variables V(t) = -70.00 jcn(t) [input=true]
+		sts = @variables V(t)=-70.00 [output=true] jcn(t) [input=true]
 		eqs = [D(V) ~ (I_in + jcn)/C]
 		ev = [V~θ] => [V~Eₘ]
 		sys = ODESystem(eqs, t, sts, p, continuous_events=[ev]; name=name)
-		new(p, sts[1], sts[2], sts[1], sys, namespace)
+
+		new(p, sys, namespace)
 	end
 end
 
@@ -599,12 +598,10 @@ References:
 # G_syn = [0.001, 0.01] μA/mV (bastardized μS - off by factor of 1000)
 # I_in = [-2.5, 2.5] μA (you will cook real neurons with these currents)
 struct LIFNeuron <: AbstractNeuronBlox
-	params
-    output
-    jcn
-	voltage
+    params
     odesystem
     namespace
+
 	function LIFNeuron(;name,
 					   namespace=nothing, 
 					   C=1.0,
@@ -617,14 +614,15 @@ struct LIFNeuron <: AbstractNeuronBlox
 					   I_in=0.0)
 		p = paramscoping(C=C, Eₘ=Eₘ, Rₘ=Rₘ, τ=τ, θ=θ, E_syn=E_syn, G_syn=G_syn, I_in=I_in)
 		C, Eₘ, Rₘ, τ, θ, E_syn, G_syn, I_in = p
-		sts = @variables V(t) = -70.00 G(t)=0.0 jcn(t) [input=true]
+		sts = @variables V(t)=-70.00 G(t)=0.0 [output=true] jcn(t) [input=true]
 		eqs = [ D(V) ~ (-(V-Eₘ)/Rₘ + I_in + jcn)/C,
 				D(G)~(-1/τ)*G,
 			  ]
 
 		ev = [V~θ] => [V~Eₘ, G~G+G_syn]
 		sys = ODESystem(eqs, t, sts, p, continuous_events=[ev]; name=name)
-		new(p, sts[2], sts[3], sts[1], sys, namespace)
+
+		new(p, sys, namespace)
 	end
 end
 
@@ -676,7 +674,7 @@ struct LIFInhNeuron <: AbstractInhNeuronBlox
             is_refractory=0
         end
 
-        sts = @variables V(t)=-52 S_AMPA(t)=0 S_GABA(t)=0 S_AMPA_ext(t)=0 jcn(t) [input=true] jcn_external(t) [input=true]
+        sts = @variables V(t)=-52 [output=true] S_AMPA(t)=0 S_GABA(t)=0 S_AMPA_ext(t)=0 jcn(t) [input=true] jcn_external(t) [input=true]
         eqs = [
             D(V) ~ (1 - is_refractory) * (- g_L * (V - V_L) - S_AMPA_ext * g_AMPA_ext * (V - V_E) - S_GABA * g_GABA * (V - V_I) - S_AMPA * g_AMPA * (V - V_E) - jcn) / C,
             D(S_AMPA) ~ - S_AMPA / τ_AMPA,
@@ -744,7 +742,7 @@ struct LIFExciNeuron <: AbstractExciNeuronBlox
             is_refractory=0
         end
 
-        sts = @variables V(t)=-52 S_AMPA(t)=0 S_GABA(t)=0 S_NMDA(t)=0 x(t)=0 S_AMPA_ext(t)=0 jcn(t) [input=true] 
+        sts = @variables V(t)=-52 [output=true] S_AMPA(t)=0 S_GABA(t)=0 S_NMDA(t)=0 x(t)=0 S_AMPA_ext(t)=0 jcn(t) [input=true] 
         eqs = [ 
             D(V) ~ (1 - is_refractory) * (- g_L * (V - V_L) - S_AMPA_ext * g_AMPA_ext * (V - V_E) - S_GABA * g_GABA * (V - V_I) - S_AMPA * g_AMPA * (V - V_E) - jcn) / C,
             D(S_AMPA) ~ - S_AMPA / τ_AMPA,
@@ -774,12 +772,10 @@ end
 # Vᵣₑₛ = [-100, -55] mV
 # θ = [0, 50] mV
 struct QIFNeuron <: AbstractNeuronBlox
-	params
-    output
-    jcn
-	voltage
+    params
     odesystem
     namespace
+
 	function QIFNeuron(;name, 
 						namespace=nothing,
 						C=1.0,
@@ -794,14 +790,15 @@ struct QIFNeuron <: AbstractNeuronBlox
 						θ=25.0)
 		p = paramscoping(C=C, Rₘ=Rₘ, E_syn=E_syn, G_syn=G_syn, τ₁=τ₁, τ₂=τ₂, I_in=I_in, Eₘ=Eₘ, Vᵣₑₛ=Vᵣₑₛ, θ=θ)
 		C, Rₘ, E_syn, G_syn, τ₁, τ₂, I_in, Eₘ, Vᵣₑₛ, θ = p
-		sts = @variables V(t) = -70.0 G(t)=0.0 z(t)=0.0 jcn(t) [input=true]
+		sts = @variables V(t)=-70.0 G(t)=0.0 [output=true] z(t)=0.0 jcn(t) [input=true]
 		eqs = [ D(V) ~ ((V-Eₘ)^2/(Rₘ^2)+I_in+jcn)/C,
 		 		D(G)~(-1/τ₂)*G + z,
 	        	D(z)~(-1/τ₁)*z
 	    	  ]
    		ev = [V~θ] => [V~Vᵣₑₛ,z~G_syn]
 		sys = ODESystem(eqs, t, sts, p, continuous_events=[ev]; name=name)
-		new(p, sts[2], sts[4], sts[1], sys, namespace)
+
+		new(p, sys, namespace)
 	end
 end
 
@@ -819,12 +816,10 @@ end
 # τ = [1, 10]
 # This is largely the Chen and Campbell Izhikevich implementation, with synaptic dynamics adjusted to reflect the LIF/QIF implementations above
 struct IzhikevichNeuron <: AbstractNeuronBlox
-	params
-    output
-    jcn
-	voltage
+    params
     odesystem
     namespace
+
 	function IzhikevichNeuron(;name,
 							   namespace=nothing,
 							   α=0.6215,
@@ -840,7 +835,7 @@ struct IzhikevichNeuron <: AbstractNeuronBlox
 							   τ=2.6)
 		p = paramscoping(α=α, η=η, a=a, b=b, θ=θ, vᵣ=vᵣ, wⱼ=wⱼ, sⱼ=sⱼ, gₛ=gₛ, eᵣ=eᵣ, τ=τ)
 		α, η, a, b, θ, vᵣ, wⱼ, sⱼ, gₛ, eᵣ, τ = p
-		sts = @variables V(t)=0.0 w(t)=0.0 G(t)=0.0 z(t)=0.0 jcn(t) [input=true]
+		sts = @variables V(t)=0.0 w(t)=0.0 G(t)=0.0 [output=true] z(t)=0.0 jcn(t) [input=true]
 		eqs = [ D(V) ~ V*(V-α) - w + η + jcn,
 				D(w) ~ a*(b*V - w),
 				D(G) ~ (-1/τ)*G + z,
@@ -848,6 +843,7 @@ struct IzhikevichNeuron <: AbstractNeuronBlox
 			  ]
 		ev = [V~θ] => [V~vᵣ, w~w+wⱼ, z~sⱼ]
 		sys = ODESystem(eqs, t, sts, p, continuous_events=[ev]; name=name)
-		new(p, sts[2], sts[5], sts[1], sys, namespace)
+
+		new(p, sys, namespace)
 	end
 end

--- a/src/blox/neuron_models.jl
+++ b/src/blox/neuron_models.jl
@@ -628,23 +628,6 @@ struct LIFNeuron <: AbstractNeuronBlox
 	end
 end
 
-function LIF_spike_affect!(integ, u, p, ctx)
-    integ.u[u[1]] = integ.p[p[1]]
-
-    t_refract_end = integ.t + integ.p[p[2]]
-    integ.p[p[3]] = t_refract_end
-
-    integ.p[p[4]] = 1
-
-    SciMLBase.add_tstop!(integ, t_refract_end)
-    
-    c = 1
-    for i in eachindex(u)[2:end]
-        integ.u[u[i]] += integ.p[p[c + 4]]
-        c += 1
-    end
-end
-
 struct LIFInhNeuron <: AbstractInhNeuronBlox
     odesystem
     namespace

--- a/src/blox/neuron_models.jl
+++ b/src/blox/neuron_models.jl
@@ -2,7 +2,7 @@ abstract type AbstractInhNeuronBlox <: AbstractNeuronBlox end
 abstract type AbstractExciNeuronBlox <: AbstractNeuronBlox end
 
 struct HHNeuronExciBlox <: AbstractExciNeuronBlox
-    odesystem
+    system
     namespace
 
 	function HHNeuronExciBlox(;
@@ -89,7 +89,7 @@ struct HHNeuronExciBlox <: AbstractExciNeuronBlox
 end	
 
 struct HHNeuronInhibBlox <: AbstractInhNeuronBlox
-    odesystem
+    system
     namespace
 	function HHNeuronInhibBlox(;
         name, 
@@ -168,7 +168,7 @@ end
 #These neurons were used in Adam et. al 2022 model for DBS
 
 struct HHNeuronInhib_MSN_Adam_Blox <: AbstractInhNeuronBlox
-    odesystem
+    system
     namespace
 
 	function HHNeuronInhib_MSN_Adam_Blox(;
@@ -256,7 +256,7 @@ struct HHNeuronInhib_MSN_Adam_Blox <: AbstractInhNeuronBlox
 end	
 
 struct HHNeuronInhib_FSI_Adam_Blox <: AbstractInhNeuronBlox
-    odesystem
+    system
     namespace
 
 	function HHNeuronInhib_FSI_Adam_Blox(;
@@ -348,7 +348,7 @@ struct HHNeuronInhib_FSI_Adam_Blox <: AbstractInhNeuronBlox
 end	
 
 struct HHNeuronExci_STN_Adam_Blox <: AbstractExciNeuronBlox
-    odesystem
+    system
     namespace
 
 	function HHNeuronExci_STN_Adam_Blox(;
@@ -428,7 +428,7 @@ struct HHNeuronExci_STN_Adam_Blox <: AbstractExciNeuronBlox
 end	
 
 struct HHNeuronInhib_GPe_Adam_Blox <: AbstractInhNeuronBlox
-    odesystem
+    system
     namespace
 
 	function HHNeuronInhib_GPe_Adam_Blox(;
@@ -541,7 +541,7 @@ References:
 # Remember: synaptic weights need to be in μA/mV, so they're very small!
 struct IFNeuron <: AbstractNeuronBlox
     params
-    odesystem
+    system
     namespace
 
 	function IFNeuron(;name,
@@ -599,7 +599,7 @@ References:
 # I_in = [-2.5, 2.5] μA (you will cook real neurons with these currents)
 struct LIFNeuron <: AbstractNeuronBlox
     params
-    odesystem
+    system
     namespace
 
 	function LIFNeuron(;name,
@@ -627,7 +627,7 @@ struct LIFNeuron <: AbstractNeuronBlox
 end
 
 struct LIFInhNeuron <: AbstractInhNeuronBlox
-    odesystem
+    system
     namespace
 
     function LIFInhNeuron(;
@@ -691,7 +691,7 @@ struct LIFInhNeuron <: AbstractInhNeuronBlox
 end
 
 struct LIFExciNeuron <: AbstractExciNeuronBlox
-    odesystem
+    system
     namespace
 
     function LIFExciNeuron(;
@@ -773,7 +773,7 @@ end
 # θ = [0, 50] mV
 struct QIFNeuron <: AbstractNeuronBlox
     params
-    odesystem
+    system
     namespace
 
 	function QIFNeuron(;name, 
@@ -817,7 +817,7 @@ end
 # This is largely the Chen and Campbell Izhikevich implementation, with synaptic dynamics adjusted to reflect the LIF/QIF implementations above
 struct IzhikevichNeuron <: AbstractNeuronBlox
     params
-    odesystem
+    system
     namespace
 
 	function IzhikevichNeuron(;name,

--- a/src/blox/ping_neuron_examples.jl
+++ b/src/blox/ping_neuron_examples.jl
@@ -37,7 +37,7 @@ Inputs:
 """
 struct PINGNeuronExci <: AbstractPINGNeuron
     params
-    odesystem
+    system
     namespace
 
     function PINGNeuronExci(;name,
@@ -111,7 +111,7 @@ Inputs:
 """
 struct PINGNeuronInhib <: AbstractPINGNeuron
     params
-    odesystem
+    system
     namespace
 
     function PINGNeuronInhib(;name,

--- a/src/blox/ping_neuron_examples.jl
+++ b/src/blox/ping_neuron_examples.jl
@@ -37,11 +37,9 @@ Inputs:
 """
 struct PINGNeuronExci <: AbstractPINGNeuron
     params
-    output
-    jcn
-    voltage
     odesystem
     namespace
+
     function PINGNeuronExci(;name,
                              namespace=nothing,
                              C=1.0,
@@ -72,7 +70,8 @@ struct PINGNeuronExci <: AbstractPINGNeuron
                D(s) ~ ((1+tanh(V/10.0))/2.0)*((1.0 - s)/τ_R) - s/τ_D
         ]
         sys = ODESystem(eqs, t, sts, p; name=name)
-        new(p, sts[4], sts[5], sts[1], sys, namespace)
+
+        new(p, sys, namespace)
     end
 end
 
@@ -112,11 +111,9 @@ Inputs:
 """
 struct PINGNeuronInhib <: AbstractPINGNeuron
     params
-    output
-    jcn
-    voltage
     odesystem
     namespace
+
     function PINGNeuronInhib(;name,
                              namespace=nothing,
                              C=1.0,
@@ -147,7 +144,8 @@ struct PINGNeuronInhib <: AbstractPINGNeuron
                D(s) ~ ((1+tanh(V/10.0))/2.0)*((1.0 - s)/τ_R) - s/τ_D
         ]
         sys = ODESystem(eqs, t, sts, p; name=name)
-        new(p, sts[4], sts[5], sts[1], sys, namespace)
+
+        new(p, sys, namespace)
         end
 end
 

--- a/src/blox/ping_neuron_examples.jl
+++ b/src/blox/ping_neuron_examples.jl
@@ -54,7 +54,7 @@ struct PINGNeuronExci <: AbstractPINGNeuron
                              τ_D=2.0)
         p = paramscoping(C=C, g_Na=g_Na, V_Na=V_Na, g_K=g_K, V_K=V_K, g_L=g_L, V_L=V_L, I_ext=I_ext, τ_R=τ_R, τ_D=τ_D)
         C, g_Na, V_Na, g_K, V_K, g_L, V_L, I_ext, τ_R, τ_D = p
-        sts = @variables V(t)=0.0 [output=true] n(t)=0.0 h(t)=0.0 s(t)=0.0 jcn(t) [input=true]
+        sts = @variables V(t)=0.0 n(t)=0.0 h(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
         
         a_m(v) = 0.32*(v+54.0)/(1.0 - exp(-(v+54.0)/4.0))
         b_m(v) = 0.28*(v+27.0)/(exp((v+27.0)/5.0) - 1.0)
@@ -128,7 +128,7 @@ struct PINGNeuronInhib <: AbstractPINGNeuron
                              τ_D=10.0)
         p = paramscoping(C=C, g_Na=g_Na, V_Na=V_Na, g_K=g_K, V_K=V_K, g_L=g_L, V_L=V_L, I_ext=I_ext, τ_R=τ_R, τ_D=τ_D)
         C, g_Na, V_Na, g_K, V_K, g_L, V_L, I_ext, τ_R, τ_D = p
-        sts = @variables V(t)=0.0 [output=true] n(t)=0.0 h(t)=0.0 s(t)=0.0 jcn(t) [input=true]
+        sts = @variables V(t)=0.0 n(t)=0.0 h(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
 
         a_m(v) = 0.1*(v+35.0)/(1.0 - exp(-(v+35.0)/10.0))
         b_m(v) = 4*exp(-(v+60.0)/18.0)

--- a/src/blox/reinforcement_learning.jl
+++ b/src/blox/reinforcement_learning.jl
@@ -190,11 +190,11 @@ mutable struct Agent{S,P,A,LR,C}
     connector::C
 
     function Agent(g::MetaDiGraph; name, kwargs...)
-        bc = connector_from_graph(g)
+        conns = connectors_from_graph(g)
         
         t_block = haskey(kwargs, :t_block) ? kwargs[:t_block] : missing
         # TODO: add another version that uses system_from_graph(g,bc,params;)
-        sys = system_from_graph(g, bc; name, t_block, allow_parameter=false)
+        sys = system_from_graph(g, conns; name, t_block, allow_parameter=false)
 
         u0 = haskey(kwargs, :u0) ? kwargs[:u0] : []
         p = haskey(kwargs, :p) ? kwargs[:p] : []
@@ -202,9 +202,9 @@ mutable struct Agent{S,P,A,LR,C}
         prob = ODEProblem(sys, u0, (0.,1.), p)
         
         policy = action_selection_from_graph(g)
-        lr =  narrowtype(learning_rules(bc))  
+        lr =  narrowtype(learning_rules(conns))  
 
-        new{typeof(sys), typeof(prob), typeof(policy), typeof(lr), typeof(bc)}(sys, prob, policy, lr, bc)
+        new{typeof(sys), typeof(prob), typeof(policy), typeof(lr), typeof(conns)}(sys, prob, policy, lr, conns)
     end
 end
 

--- a/src/blox/reinforcement_learning.jl
+++ b/src/blox/reinforcement_learning.jl
@@ -183,7 +183,7 @@ get_eval_times(gp::GreedyPolicy) = [gp.t_decision]
 get_eval_states(gp::GreedyPolicy) = gp.competitor_states
 
 mutable struct Agent{S,P,A,LR,C}
-    odesystem::S
+    system::S
     problem::P
     action_selection::A
     learning_rules::LR

--- a/src/blox/rl_blox.jl
+++ b/src/blox/rl_blox.jl
@@ -13,7 +13,7 @@ mutable struct LearningBlox
         NeuralMass = HarmonicOscillatorBlox(ω=ω, ζ=1.0, k=(ω)^2, h=d, name=Symbol(String(name)*"_NeuralMass"))
         # Create System
         blox  = [Phase, Cosine, NeuralMass]
-        sys   = [s.odesystem for s in blox]
+        sys   = [s.system for s in blox]
         # Set Internal Connections
         # Columns = Inputs (Sinks); Rows = Outputs (Sources)
                # P C NM

--- a/src/blox/sources.jl
+++ b/src/blox/sources.jl
@@ -1,13 +1,13 @@
 # Simple input blox
 mutable struct ExternalInput <: StimulusBlox
     namespace
-    odesystem
+    system
 
     function ExternalInput(;name, I=1.0, namespace=nothing)
         sts = @variables u(t) [output=true, irreducible=true, description="ext_input"]
         eqs = [u ~ I]
         odesys = System(eqs, t, sts, []; name=name)
-        
+
         new(namespace, odesys)
     end
 end
@@ -20,7 +20,7 @@ mutable struct CosineSource
     offset::Num
     tstart::Num
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     function CosineSource(;name, f=18, a=10, phi=0, offset=0, tstart=0)
         @named source = Blocks.Cosine(frequency=f, amplitude=a, phase=phi, 		 
                         offset=offset, start_time=tstart, smooth=false)	
@@ -34,7 +34,7 @@ mutable struct CosineBlox
     frequency::Num
     phase::Num
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     function CosineBlox(;name, amplitude=1, frequency=20, phase=0)
 
         sts    = @variables jcn(t) u(t)=0.0
@@ -52,7 +52,7 @@ mutable struct NoisyCosineBlox
     amplitude::Num
     frequency::Num
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     function NoisyCosineBlox(;name, amplitude=1, frequency=20) 
 
         sts    = @variables  u(t)=0.0 jcn(t)
@@ -68,7 +68,7 @@ end
 #PhaseBlox
 mutable struct PhaseBlox
     connector::Num
-    odesystem::ODESystem
+    system::ODESystem
     function PhaseBlox(;name, phase_range=0, phase_data=0) 
 
         data        = convert(Vector{Float64}, phase_data)
@@ -98,7 +98,7 @@ end
 
 mutable struct ImageStimulus <: StimulusBlox
     const namespace
-    const odesystem
+    const system
     const IMG # Matrix[pixels X stimuli]
     const stim_parameters
     const category

--- a/src/blox/sources.jl
+++ b/src/blox/sources.jl
@@ -1,13 +1,14 @@
 # Simple input blox
 mutable struct ExternalInput <: StimulusBlox
     namespace
-    output::Num
-    odesystem::ODESystem
+    odesystem
+
     function ExternalInput(;name, I=1.0, namespace=nothing)
-        sts = @variables u(t) [irreducible=true, description="ext_input"]
+        sts = @variables u(t) [output=true, irreducible=true, description="ext_input"]
         eqs = [u ~ I]
         odesys = System(eqs, t, sts, []; name=name)
-        new(namespace, sts[1], odesys)
+        
+        new(namespace, odesys)
     end
 end
 

--- a/src/blox/stochastic.jl
+++ b/src/blox/stochastic.jl
@@ -15,8 +15,6 @@ mutable struct OUBlox <: NeuralMassBlox
     # all parameters are Num as to allow symbolic expressions
     namespace
     stochastic
-    output
-    input
     odesystem
     function OUBlox(;name, namespace=nothing, μ=0.0, σ=1.0, τ=1.0)
         p = paramscoping(μ=μ, τ=τ, σ=σ)
@@ -26,7 +24,7 @@ mutable struct OUBlox <: NeuralMassBlox
 
         eqs = [D(x) ~ -(x-μ)/τ + jcn + sqrt(2/τ)*σ*w]
         sys = System(eqs, t; name=name)
-        new(namespace, true, sts[1], sts[2], sys)
+        new(namespace, true, sys)
     end
 end
 

--- a/src/blox/stochastic.jl
+++ b/src/blox/stochastic.jl
@@ -15,7 +15,7 @@ mutable struct OUBlox <: NeuralMassBlox
     # all parameters are Num as to allow symbolic expressions
     namespace
     stochastic
-    odesystem
+    system
     function OUBlox(;name, namespace=nothing, μ=0.0, σ=1.0, τ=1.0)
         p = paramscoping(μ=μ, τ=τ, σ=σ)
         μ, τ, σ = p
@@ -51,7 +51,7 @@ end
 #     stochastic
 #     output
 #     input
-#     odesystem
+#     system
 #     function OUCouplingBlox(;name, namespace, μ=0.0, σ=1.0, τ=1.0)
 #         p = paramscoping(μ=μ, τ=τ, σ=σ)
 #         μ, τ, σ = p

--- a/src/blox/subcortical_blox.jl
+++ b/src/blox/subcortical_blox.jl
@@ -6,7 +6,7 @@
 struct Striatum <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
 
@@ -83,7 +83,7 @@ end
 struct GPi <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
 
@@ -139,7 +139,7 @@ end
 struct GPe <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
 
@@ -195,7 +195,7 @@ end
 struct Thalamus <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
 
@@ -250,7 +250,7 @@ end
 struct STN <: CompositeBlox
     namespace
     parts
-    odesystem
+    system
     connector
     mean
 

--- a/src/blox/subcortical_blox.jl
+++ b/src/blox/subcortical_blox.jl
@@ -51,7 +51,7 @@ struct Striatum <: CompositeBlox
         if !isnothing(namespace)
             add_blox!(g, matrisome)
             add_blox!(g, striosome)
-            bc = connector_from_graph(g)
+            bc = connectors_from_graph(g)
             sys = system_from_parts(parts; name)
 
             @variables t
@@ -60,7 +60,7 @@ struct Striatum <: CompositeBlox
             
             new(namespace, parts, sys, bc, m)
         else
-            bc = connector_from_graph(g)
+            bc = connectors_from_graph(g)
             sys = system_from_graph(g, bc; name, simplify=false)
 
             m = [s for s in unknowns.((sys,), unknowns(sys)) if contains(string(s), "V(t)")]
@@ -119,7 +119,7 @@ struct GPi <: CompositeBlox
 
         parts = n_inh
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
         m = if isnothing(namespace) 
@@ -175,7 +175,7 @@ struct GPe <: CompositeBlox
 
         parts = n_inh
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
         m = if isnothing(namespace) 
@@ -231,7 +231,7 @@ struct Thalamus <: CompositeBlox
 
         parts = n_exci
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
         m = if isnothing(namespace) 
@@ -286,7 +286,7 @@ struct STN <: CompositeBlox
 
         parts = n_exci
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)
         
         # TO DO : m is a subset of unknowns to be plotted in the GUI. 

--- a/src/blox/winnertakeall.jl
+++ b/src/blox/winnertakeall.jl
@@ -56,7 +56,7 @@ struct WinnerTakeAllBlox{P} <: CompositeBlox
 
         parts = vcat(n_inh, n_excis)
         
-        bc = connector_from_graph(g)
+        bc = connectors_from_graph(g)
         # If a namespace is not provided, assume that this is the highest level
         # and construct the ODEsystem from the graph.
         sys = isnothing(namespace) ? system_from_graph(g, bc; name, simplify=false) : system_from_parts(parts; name)

--- a/src/blox/winnertakeall.jl
+++ b/src/blox/winnertakeall.jl
@@ -8,7 +8,7 @@ and receive feedback inhibition from that interneuron.
 struct WinnerTakeAllBlox{P} <: CompositeBlox
     namespace
     parts::Vector{P}
-    odesystem
+    system
     connector
 
     function WinnerTakeAllBlox(; 

--- a/src/measurementmodels/fmri.jl
+++ b/src/measurementmodels/fmri.jl
@@ -45,10 +45,9 @@ Citations:
 """
 struct BalloonModel <: ObserverBlox
     params
-    output
-    jcn
     odesystem
     namespace
+
     function BalloonModel(;name, namespace=nothing, lnκ=0.0, lnτ=0.0, lnϵ=0.0)
         #= hemodynamic parameters
             H[1] - signal decay                                   d(ds/dt)/ds)
@@ -85,7 +84,7 @@ struct BalloonModel <: ObserverBlox
             bold   ~ B[2]*(k1 - k1*exp(lnq) + exp(lnϵ)*B[3]*B[5]*B[1] - exp(lnϵ)*B[3]*B[5]*B[1]*exp(lnq)/exp(lnν) + 1-exp(lnϵ) - (1-exp(lnϵ))*exp(lnν))
         ]
         sys = System(eqs, t; name=name)
-        new(p, Num(0), sts[5], sys, namespace)
+        new(p, sys, namespace)
     end
 end
 

--- a/src/measurementmodels/fmri.jl
+++ b/src/measurementmodels/fmri.jl
@@ -45,7 +45,7 @@ Citations:
 """
 struct BalloonModel <: ObserverBlox
     params
-    odesystem
+    system
     namespace
 
     function BalloonModel(;name, namespace=nothing, lnκ=0.0, lnτ=0.0, lnϵ=0.0)

--- a/src/measurementmodels/lfp.jl
+++ b/src/measurementmodels/lfp.jl
@@ -1,8 +1,6 @@
 # Lead field function for LFPs
 struct LeadField <: ObserverBlox
     params
-    output
-    jcn
     odesystem
     namespace
 
@@ -17,6 +15,6 @@ struct LeadField <: ObserverBlox
         ]
 
         sys = System(eqs, t; name=name)
-        new(p, Num(0), sts[2], sys, namespace)
+        new(p, sys, namespace)
     end
 end

--- a/src/measurementmodels/lfp.jl
+++ b/src/measurementmodels/lfp.jl
@@ -1,7 +1,7 @@
 # Lead field function for LFPs
 struct LeadField <: ObserverBlox
     params
-    odesystem
+    system
     namespace
 
     function LeadField(;name, namespace=nothing, L=1.0)

--- a/test/GraphDynamicsTests/test_suite.jl
+++ b/test/GraphDynamicsTests/test_suite.jl
@@ -171,7 +171,7 @@ function neuron_and_neural_mass_comparison_tests()
                         JansenRit(name=:jr1)
                         JansenRit(name=:jr2)],
                        )
-            if length(unknowns(LIFNeuron(;name=:_).odesystem)) > 3
+            if length(unknowns(LIFNeuron(;name=:_).system)) > 3
                 @warn "excluding LIFNeurons from test"
                 filter!(x -> !(x isa LIFNeuron), neurons) # there was a bug in how LIFNeurons were implemented
             end

--- a/test/components.jl
+++ b/test/components.jl
@@ -265,7 +265,7 @@ end
     """
     @named macroscopic_model = next_generation(C=30, Δ=1.0, η_0=5.0, v_syn=-10, alpha_inv=35, k=0.105)
     sim_dur = 1000.0 
-    sol = simulate(structural_simplify(macroscopic_model.odesystem), [0.5 + 0.0im, 1.6 + 0.0im], (0.0, sim_dur), [], Tsit5(); saveat=0.01,reltol=1e-4,abstol=1e-4)
+    sol = simulate(structural_simplify(macroscopic_model.system), [0.5 + 0.0im, 1.6 + 0.0im], (0.0, sim_dur), [], Tsit5(); saveat=0.01,reltol=1e-4,abstol=1e-4)
 
     C=30
     W = (1 .- conj.(sol[!,"Z(t)"]))./(1 .+ conj.(sol[!,"Z(t)"]))
@@ -291,7 +291,7 @@ Test for OUBlox generator.
 
 @testset "OUBlox " begin
     @named ou1 = OUBlox()
-    sys = [ou1.odesystem]
+    sys = [ou1.system]
     eqs = [sys[1].jcn ~ 0.0]
     @named ou1connected = compose(System(eqs, t; name=:connected),sys)
     ousimpl = structural_simplify(ou1connected)
@@ -324,7 +324,7 @@ end
 @testset "OUBlox & Janset-Rit network" begin
     @named ou = OUBlox(σ=5.0)
     @named jr = JansenRit()    
-    sys = [ou.odesystem, jr.odesystem]
+    sys = [ou.system, jr.system]
     eqs = [sys[1].jcn ~ 0.0, sys[2].jcn ~ sys[1].x]
     @named ou1connected = compose(System(eqs, t; name=:connected),sys)
     sys = structural_simplify(ou1connected)
@@ -341,7 +341,7 @@ end
 #     @named oucp = OUBlox(μ=2.0, σ=1.0, τ=1.0)
 #     g = MetaDiGraph()
 #     add_blox!.(Ref(g), [coupling, ou, oucp])
-#     add_edge!(g, 2, 1, Dict(:weight => ou.odesystem.x))
+#     add_edge!(g, 2, 1, Dict(:weight => ou.system.x))
 #     @named sys = system_from_graph(g)
 #     ousimpl = structural_simplify(sys)
 #     prob_oucp = SDEProblem(ousimpl,[],(0.0,10.0))
@@ -353,7 +353,7 @@ end
 # @testset "OUBlox-OUCouplingBlox network" begin
 #     @named ou1 = OUBlox()
 #     @named oucp = OUCouplingBlox(μ=2.0, σ=1.0, τ=1.0)
-#     sys = [ou1.odesystem, oucp.odesystem]
+#     sys = [ou1.system, oucp.system]
 #     eqs = [sys[1].jcn ~ 0.0, sys[2].jcn ~ sys[1].x]
 #     @named ou1connected = compose(System(eqs, t;name=:connected),sys)
 #     ousimpl = structural_simplify(ou1connected)
@@ -368,7 +368,7 @@ end
 #     @named ou2 = OUBlox(μ=0.0, σ=1.0, τ=3.0)
 #     @named oucp1 = OUCouplingBlox(μ=-0.1, σ=0.02, τ=10)
 #     @named oucp2 = OUCouplingBlox(μ=-0.2, σ=0.02, τ=10)
-#     sys = [ou1.odesystem, ou2.odesystem, oucp1.odesystem, oucp2.odesystem]
+#     sys = [ou1.system, ou2.system, oucp1.system, oucp2.system]
 #     eqs = [sys[1].jcn ~ oucp1.connector,
 #            sys[2].jcn ~ oucp2.connector,
 #            sys[3].jcn ~ ou2.connector,
@@ -393,7 +393,7 @@ end
 #     @named Str2 = jansen_ritC(τ=0.0022, H=20, λ=300, r=0.3)
 #     @parameters phase_input = 0
 
-#     sys = [Str2.odesystem]
+#     sys = [Str2.system]
 #     eqs = [sys[1].jcn ~ phase_input]
 #     @named phase_system = ODESystem(eqs,systems=sys)
 #     phase_system_simpl = structural_simplify(phase_system)
@@ -471,7 +471,7 @@ end
 @testset "WinnerTakeAll" begin
     N_exci = 5
     @named wta= WinnerTakeAllBlox(;I_bg=5.0*rand(N_exci), N_exci)
-    sys = wta.odesystem
+    sys = wta.system
     wta_simp=structural_simplify(sys)
     prob = ODEProblem(wta_simp,[],(0,10))
     sol = solve(prob, Vern7(), saveat=0.1)
@@ -497,7 +497,7 @@ end
 
 @testset "Cortical" begin
     @named cb = CorticalBlox(N_wta=6, N_exci=5, density=0.1, weight=1)
-    cb_simpl = structural_simplify(cb.odesystem)
+    cb_simpl = structural_simplify(cb.system)
     prob = ODEProblem(cb_simpl, [], (0, 2))
     sol = solve(prob, Vern7(), saveat=0.5)
     @test sol.retcode == ReturnCode.Success 
@@ -505,7 +505,7 @@ end
 
 @testset "Striatum" begin
     @named str_scb = Striatum(N_inhib=2)
-    str_simpl = structural_simplify(str_scb.odesystem)
+    str_simpl = structural_simplify(str_scb.system)
     prob = ODEProblem(str_simpl, [], (0, 2))
     sol = solve(prob, Vern7(), saveat=0.5)
     @test sol.retcode == ReturnCode.Success 
@@ -513,7 +513,7 @@ end
 
 @testset "GPi" begin
     @named gpi_scb = GPi(N_inhib=2)
-    gpi_simpl = structural_simplify(gpi_scb.odesystem)
+    gpi_simpl = structural_simplify(gpi_scb.system)
     prob = ODEProblem(gpi_simpl, [], (0, 2))
     sol = solve(prob, Vern7(), saveat=0.5)
     @test sol.retcode == ReturnCode.Success 
@@ -521,7 +521,7 @@ end
 
 @testset "GPe" begin
     @named gpe_scb = GPe(N_inhib=2)
-    gpe_simpl = structural_simplify(gpe_scb.odesystem)
+    gpe_simpl = structural_simplify(gpe_scb.system)
     prob = ODEProblem(gpe_simpl, [], (0, 2))
     sol = solve(prob, Vern7(), saveat=0.5)
     @test sol.retcode == ReturnCode.Success 
@@ -529,7 +529,7 @@ end
 
 @testset "STN" begin
     @named stn_scb = STN(N_exci=2)
-    stn_simpl = structural_simplify(stn_scb.odesystem)
+    stn_simpl = structural_simplify(stn_scb.system)
     prob = ODEProblem(stn_simpl, [], (0, 2))
     sol = solve(prob, Vern7(), saveat=0.5)
     @test sol.retcode == ReturnCode.Success 
@@ -537,7 +537,7 @@ end
 
 @testset "Thalamus" begin
     @named thal_scb = Thalamus(N_exci=2)
-    thal_simpl = structural_simplify(thal_scb.odesystem)
+    thal_simpl = structural_simplify(thal_scb.system)
     prob = ODEProblem(thal_simpl, [], (0, 2))
     sol = solve(prob, Vern7(), saveat=0.5)
     @test sol.retcode == ReturnCode.Success 
@@ -680,7 +680,7 @@ end
 @testset "LIFExciCircuitBlox" begin
     @named n = LIFExciCircuitBlox(; N_neurons = 10, weight=1)
 
-    sys_simpl = structural_simplify(n.odesystem)
+    sys_simpl = structural_simplify(n.system)
     prob = ODEProblem(sys_simpl, [], (0, 200.0))
     sol = solve(prob, Vern7())
     @test sol.retcode == ReturnCode.Success 

--- a/test/plasticity.jl
+++ b/test/plasticity.jl
@@ -33,7 +33,7 @@ using ModelingToolkit: getp
     add_edge!(g, d[VAC], d[PFC], Dict(:weight => 1, :density => 0.1, :learning_rule => hebbian))
 
     agent = Agent(g; name=:ag);
-    ps = parameters(agent.odesystem)
+    ps = parameters(agent.system)
     init_params = agent.problem.p
     map_idxs = Int.(ModelingToolkit.varmap_to_vars([ps[i] => i for i in eachindex(ps)], ps))
     idxs_weight = findall(x -> occursin("w_", String(Symbol(x))), ps)
@@ -42,7 +42,7 @@ using ModelingToolkit: getp
     idxs_other_params = setdiff(eachindex(ps), vcat(idxs_weight, idx_stim, idx_jcn))
 
 
-    params_at(idxs) = getp(agent.problem, parameters(agent.odesystem)[idxs])(agent.problem)
+    params_at(idxs) = getp(agent.problem, parameters(agent.system)[idxs])(agent.problem)
     init_params_all = params_at(:)
     init_params_idxs_weight = params_at(idxs_weight)
     init_params_idxs_other_params = params_at(idxs_other_params)

--- a/test/reinforcement_learning.jl
+++ b/test/reinforcement_learning.jl
@@ -48,7 +48,7 @@ using ModelingToolkit: getp
     add_edge!(g, d[TAN_pop], d[STR_R], Dict(:weight => 1, :t_event => 0.1*t_trial))
 
     agent = Agent(g; name=:ag, t_block = t_trial/5);
-    ps = parameters(agent.odesystem)
+    ps = parameters(agent.system)
 
     
     map_idxs = Int.(ModelingToolkit.varmap_to_vars([ps[i] => i for i in eachindex(ps)], ps))
@@ -60,7 +60,7 @@ using ModelingToolkit: getp
     idx_I_bg = findall(x -> occursin("I_bg", String(Symbol(x))), ps)
     idxs_other_params = setdiff(eachindex(ps), vcat(idxs_weight, idx_stim, idx_jcn, idx_spikes, idx_H, idx_I_bg))
 
-    params_at(idxs) = getp(agent.problem, parameters(agent.odesystem)[idxs])(agent.problem)
+    params_at(idxs) = getp(agent.problem, parameters(agent.system)[idxs])(agent.problem)
     init_params_all = params_at(:)
     init_params_idxs_weight = params_at(idxs_weight)
     init_params_idxs_other_params = params_at(idxs_other_params)
@@ -124,7 +124,7 @@ end
     add_edge!(g, d[TAN_pop], d[STR_R], Dict(:weight => 1, :t_event => 0.1*t_trial))
 
     agent = Agent(g; name=:ag, t_block = t_trial/5);
-    ps = parameters(agent.odesystem)
+    ps = parameters(agent.system)
 
     
     map_idxs = Int.(ModelingToolkit.varmap_to_vars([ps[i] => i for i in eachindex(ps)], ps))
@@ -136,7 +136,7 @@ end
     idx_I_bg = findall(x -> occursin("I_bg", String(Symbol(x))), ps)
     idxs_other_params = setdiff(eachindex(ps), vcat(idxs_weight, idx_stim, idx_jcn, idx_spikes, idx_H, idx_I_bg))
 
-    params_at(idxs) = getp(agent.problem, parameters(agent.odesystem)[idxs])(agent.problem)
+    params_at(idxs) = getp(agent.problem, parameters(agent.system)[idxs])(agent.problem)
     init_params_all = params_at(:)
     init_params_idxs_weight = params_at(idxs_weight)
     init_params_idxs_other_params = params_at(idxs_other_params)

--- a/test/source_components.jl
+++ b/test/source_components.jl
@@ -8,7 +8,7 @@ CosineSource Test
 @named int = Integrator()
 # CosineBlox
 @named src_nb   = CosineSource(f=1, a=2, phi=0, offset=1, tstart=2)
-@named iosys_nb = ODESystem([connect(src_nb.odesystem.output, int.input)], t, systems = [int, src_nb.odesystem])
+@named iosys_nb = ODESystem([connect(src_nb.system.output, int.input)], t, systems = [int, src_nb.system])
 sys_nb = structural_simplify(iosys_nb)
 # Cosine MTK
 @named src     = Blocks.Cosine(frequency=1, amplitude=2, phase=0, offset=1, start_time=2)


### PR DESCRIPTION
Extends `ModelingToolkit.outputs(blox)` function to return all namespaced variables/parameters tagged with `[output=true]` in a blox (not system).

Also did a lot of cleanup of unnecessary fields like `jcn` and `voltage` and finally renamed `odesystem -> system`.