### PR TITLE
Update install instructions to use NeurobloxRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,28 @@ Neuroblox.jl is designed for computational neuroscience and psychiatry applicati
 
 ## Description
 Neuroblox.jl is based on a library of modular computational building blocks (“blox”) in the form of systems of symbolic dynamic differential equations that can be combined to describe large-scale brain dynamics.  Once a model is built, it can be simulated efficiently and fit electrophysiological and neuroimaging data.  Moreover, the circuit behavior of multiple model variants can be investigated to aid in distinguishing between competing hypotheses.
-We employ ModelingToolkit.jl to describe the dynamical behavior of blox as symbolic (stochastic/delay) differential equations.  Our libraries of modular blox consist of individual neurons (Hodgkin-Huxley, IF, QIF, LIF, etc.), neural mass models (Jansen-Rit, Wilson-Cowan, Lauter-Breakspear, Next Generation, microcanonical circuits etc.) and biomimetically-constrained control circuit elements.  A GUI designed to be intuitive to neuroscientists allows researchers to build models that automatically generate high-performance systems of numerical ordinary/stochastic differential equations from which one can run stimulations with parameters fit to experimental data.  Our benchmarks show that the increase in speed for simulation often exceeds a factor of 100 as compared to neural mass model implementation by the Virtual Brain (python) and similar packages in MATLAB.  For parameter fitting of brain circuit dynamical models, we use Turing.jl to perform probabilistic modeling, including Hamilton-Monte-Carlo sampling and Automated Differentiation Variational Inference.
+We employ ModelingToolkit.jl to describe the dynamical behavior of blox as symbolic (stochastic/delay) differential equations.  Our libraries of modular blox consist of individual neurons (Hodgkin-Huxley, IF, QIF, LIF, etc.), neural mass models (Jansen-Rit, Wilson-Cowan, Lauter-Breakspear, Next Generation, microcanonical circuits etc.) and biomimetically-constrained control circuit elements.  A GUI designed to be intuitive to neuroscientists allows researchers to build models that automatically generate high-performance systems of numerical ordinary/stochastic differential equations from which one can run stimulations with parameters fit to experimental data.  Our benchmarks show that the increase in speed for simulation often exceeds a factor of 100 as compared to neural mass model implementation by the Virtual Brain (python** and similar packages in MATLAB.  For parameter fitting of brain circuit dynamical models, we use Turing.jl to perform probabilistic modeling, including Hamilton-Monte-Carlo sampling and Automated Differentiation Variational Inference.
+
+## Installation
+
+Neuroblox is available in the [NeurobloxRegistry](add https://github.com/Neuroblox/NeurobloxRegistry). In order to install the NeurobloxRegistry simply run
+
+``` julia
+using Pkg
+pkg"registry add https://github.com/Neuroblox/NeurobloxRegistry"
+```
+
+and then Neuroblox can be installed like any other julia package with
+
+``` julia
+Pkg.add("Neuroblox)
+```
+
+If this is your first time using Julia, you *may* also need to add the General registry, which can be done with
+```
+pkg"registry add General"
+```
+
 
 ## Licensing
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -1,16 +1,17 @@
 # Installing Neuroblox
 
-To install Neuroblox.jl, you need to first add the JuliaHubRegistry your list of registries that julia checks for available package 
+To install Neuroblox.jl, you need to first add the [NeurobloxRegistry](https://github.com/Neuroblox/NeurobloxRegistry) to your list of registries that julia checks for available packages
 
 ```julia
 using Pkg
-Pkg.add("PkgAuthentication")
-using PkgAuthentication
-PkgAuthentication.install("juliahub.com")
-Pkg.Registry.add()
+pkg"registry add https://github.com/Neuroblox/NeurobloxRegistry"
+```
+If this is your first time using Julia, you *may* also need to add the General registry, which can be done with
+```
+pkg"registry add General"
 ```
 
-The next step is to install Neuroblox from the JuliaHubRegistry. It is also useful to install some other packages that are commonly used with Neuroblox. These packages are used in the tutorials of the next section. We have included Neuroblox and these other packages into a single `Project.toml` file which you can download and then use it to activate a new environment where all the necessary packages will be installed. To do this first choose a folder where you want this environment to be generated in and then run 
+The next step is to install Neuroblox from the NeurobloxRegistry. It is also useful to install some other packages that are commonly used with Neuroblox. These packages are used in the tutorials of the next section. We have included Neuroblox and these other packages into a single `Project.toml` file which you can download and then use it to activate a new environment where all the necessary packages will be installed. To do this first choose a folder where you want this environment to be generated in and then run 
 
 ``` julia 
 using Downloads


### PR DESCRIPTION
This changes the README and docs to instruct users on how to install neuroblox using the NeurobloxRegistry (instead of the JuliaHub Registry)