### PR TITLE
Replace symbolic jacobian with AD jacobian in spDCM

### DIFF
--- a/docs/src/tutorials/spectralDCM.jl
+++ b/docs/src/tutorials/spectralDCM.jl
@@ -68,14 +68,14 @@ for idx in CartesianIndices(A_true)
 end
 
 # finally we compose the simulation model
-@named simmodel = system_from_graph(g, split=false)
+@named simmodel = system_from_graph(g)
 
 # ## Run the simulation and plot the results
 
 # setup simulation of the model, time in seconds
 tspan = (0.0, 512.0)
 prob = SDEProblem(simmodel, [], tspan)
-dt = 2   # 2 seconds (units are milliseconds) as measurement interval for fMRI
+dt = 2   # 2 seconds (units are seconds) as measurement interval for fMRI
 sol = solve(prob, ImplicitRKMil(), saveat=dt);
 
 # we now want to extract all the variables in our model which carry the tag "measurement". For this purpose we can use the Neuroblox function `get_idx_tagged_vars`
@@ -166,12 +166,28 @@ untune = Dict(A[3] => false, A[7] => false)
 fitmodel = changetune(fitmodel, untune)                 # 3 and 7 are not present in the simulation model
 fitmodel = structural_simplify(fitmodel, split=false)   # and now simplify the euqations; the `split` parameter is necessary for some ModelingToolkit peculiarities and will soon be removed. So don't lose time with it ;)
 
+# using DifferentiationInterface
+# using Enzyme: Enzyme
+# relevant post: https://discourse.julialang.org/t/enzyme-autodiff-functor-which-contains-cache/121105/2
+# other stuff: https://github.com/EnzymeAD/Enzyme.jl/issues/1719, https://discourse.julialang.org/t/enzyme-autodiff-readonly-error-and-working-with-batches-of-data/123012 
+
+# v =  0.001*randn(21)
+# f = generate_function(fitmodel; expression=Val{false})[1]
+# f_at(params, t) = states -> f(states, params, t)
+# derivatives = params -> jacobian(f_at(addnontunableparams(params, fitmodel), 0.0), AutoEnzyme(function_annotation=Enzyme.Duplicated), v)
+# derivatives(ones(22))
+
+# jac = generate_jacobian(fitmodel; expression=Val{false})[1]
+# jac(statevals, addnontunableparams(rand(10), fitmodel), 0.0)
+
 # ## Setup spectral DCM
 max_iter = 128;            # maximum number of iterations
 ## attribute initial conditions to states
 sts, _ = get_dynamic_states(fitmodel);
+sts = unknowns(fitmodel)
+rv = rand(length(sts))
 # the following step is needed if the model's Jacobian would give degenerate eigenvalues when expanded around the fixed point 0 (which is the default expansion). We simply add small random values to avoid this degeneracy:
-perturbedfp = Dict(sts .=> abs.(0.001*rand(length(sts))))     # slight noise to avoid issues with Automatic Differentiation.
+perturbedfp = OrderedDict(sts .=> abs.(0.001*rv[1:length(sts)]))     # slight noise to avoid issues with Automatic Differentiation.
 # For convenience we can use the default prior function to use standardized prior values as given in SPM:
 pmean, pcovariance, indices = defaultprior(fitmodel, nr)
 

--- a/docs/src/tutorials/spectralDCM.jl
+++ b/docs/src/tutorials/spectralDCM.jl
@@ -166,20 +166,6 @@ untune = Dict(A[3] => false, A[7] => false)
 fitmodel = changetune(fitmodel, untune)                 # 3 and 7 are not present in the simulation model
 fitmodel = structural_simplify(fitmodel, split=false)   # and now simplify the euqations; the `split` parameter is necessary for some ModelingToolkit peculiarities and will soon be removed. So don't lose time with it ;)
 
-# using DifferentiationInterface
-# using Enzyme: Enzyme
-# relevant post: https://discourse.julialang.org/t/enzyme-autodiff-functor-which-contains-cache/121105/2
-# other stuff: https://github.com/EnzymeAD/Enzyme.jl/issues/1719, https://discourse.julialang.org/t/enzyme-autodiff-readonly-error-and-working-with-batches-of-data/123012 
-
-# v =  0.001*randn(21)
-# f = generate_function(fitmodel; expression=Val{false})[1]
-# f_at(params, t) = states -> f(states, params, t)
-# derivatives = params -> jacobian(f_at(addnontunableparams(params, fitmodel), 0.0), AutoEnzyme(function_annotation=Enzyme.Duplicated), v)
-# derivatives(ones(22))
-
-# jac = generate_jacobian(fitmodel; expression=Val{false})[1]
-# jac(statevals, addnontunableparams(rand(10), fitmodel), 0.0)
-
 # ## Setup spectral DCM
 max_iter = 128;            # maximum number of iterations
 ## attribute initial conditions to states
@@ -206,23 +192,17 @@ _, s_bold = get_eqidx_tagged_vars(fitmodel, "measurement");    # get bold signal
 # Prepare the DCM. This function will setup the computation of the Dynamic Causal Model. The last parameter specifies that wer are using fMRI time series as opposed to LFPs.
 (state, setup) = setup_sDCM(dfsol[:, String.(Symbol.(s_bold))], fitmodel, perturbedfp, csdsetup, priors, hyperpriors, indices, pmean, "fMRI");
 
-## HACK: on machines with very small amounts of RAM, Julia can run out of stack space while compiling the code called in this loop
-## this should be rewritten to abuse the compiler less, but for now, an easy solution is just to run it with more allocated stack space.
-with_stack(f, n) = fetch(schedule(Task(f, n)));
-
 # We are now ready to run the optimization procedure! :)
 # That is we loop over run_sDCM_iteration! which will alter `state` after each optimization iteration. It essentially computes the Variational Laplace estimation of expectation and variance of the tunable parameters. 
-with_stack(5_000_000) do  # 5MB of stack space
-    for iter in 1:max_iter
-        state.iter = iter
-        run_sDCM_iteration!(state, setup)
-        print("iteration: ", iter, " - F:", state.F[end] - state.F[2], " - dF predicted:", state.dF[end], "\n")
-        if iter >= 4
-            criterion = state.dF[end-3:end] .< setup.tolerance
-            if all(criterion)
-                print("convergence\n")
-                break
-            end
+for iter in 1:max_iter
+    state.iter = iter
+    run_sDCM_iteration!(state, setup)
+    print("iteration: ", iter, " - F:", state.F[end] - state.F[2], " - dF predicted:", state.dF[end], "\n")
+    if iter >= 4
+        criterion = state.dF[end-3:end] .< setup.tolerance
+        if all(criterion)
+            print("convergence\n")
+            break
         end
     end
 end

--- a/docs/src/tutorials/spectralDCM.jl
+++ b/docs/src/tutorials/spectralDCM.jl
@@ -179,9 +179,9 @@ priors = (μθ_pr = pmean,
           Σθ_pr = pcovariance
          );
 # Setup hyper parameter prior as well:
-hyperpriors = Dict(:Πλ_pr => 128.0*ones(1, 1),   # prior metaparameter precision, needs to be a matrix
-                   :μλ_pr => [8.0]               # prior metaparameter mean, needs to be a vector
-                  );
+hyperpriors = (Πλ_pr = 128.0*ones(1, 1),   # prior metaparameter precision, needs to be a matrix
+               μλ_pr = [8.0]               # prior metaparameter mean, needs to be a vector
+              );
 # To compute the cross spectral densities we need to provide the sampling interval of the time series, the frequency axis and the order of the multivariate autoregressive model:
 csdsetup = (mar_order = p, freq = freq, dt = dt);
 # earlier we used the function `get_idx_tagged_vars` to get the indices of tagged variables. Here we don't want to get the indices but rather the symbolic variable names themselves.

--- a/ext/MakieExtension.jl
+++ b/ext/MakieExtension.jl
@@ -66,7 +66,7 @@ end
 argument_names(::Type{<: FreeEnergy}) = (:spDCMresults)
 
 function Makie.plot!(p::FreeEnergy)
-    F = p.spDCMresults[].F
+    F = copy(p.spDCMresults[].F)
     deleteat!(F, 1)   # remove the first value since that's always -Inf
     
     ax = current_axis()

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -17,9 +17,7 @@ using Reexport
 using Graphs
 using MetaGraphs
 
-using ForwardDiff: Dual, Partials
-using DifferentiationInterface
-using Enzyme: Enzyme
+using ForwardDiff: Dual, Partials, jacobian
 using ForwardDiff
 ForwardDiff.can_dual(::Type{Complex{Float64}}) = true
 using ChainRules: _eigen_norm_phase_fwd!

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -17,7 +17,9 @@ using Reexport
 using Graphs
 using MetaGraphs
 
-using ForwardDiff: Dual, Partials, jacobian
+using ForwardDiff: Dual, Partials
+using DifferentiationInterface
+using Enzyme: Enzyme
 using ForwardDiff
 ForwardDiff.can_dual(::Type{Complex{Float64}}) = true
 using ChainRules: _eigen_norm_phase_fwd!

--- a/src/blox/sources.jl
+++ b/src/blox/sources.jl
@@ -19,8 +19,8 @@ mutable struct ExternalInput <: StimulusBlox
     namespace
     system
 
-    function ExternalInput(;name, I=1.0, namespace=nothing)
-        sts = @variables u(t) [output=true, irreducible=true, description="ext_input"]
+    function ExternalInput(;name, I=0.0, namespace=nothing)
+        sts = @variables u(t)=0.0 [output=true, irreducible=true, description="ext_input"]
         eqs = [u ~ I]
         odesys = System(eqs, t, sts, []; name=name)
 

--- a/src/datafitting/spDCM_VL.jl
+++ b/src/datafitting/spDCM_VL.jl
@@ -410,12 +410,10 @@ function setup_sDCM(data, model, initcond, csdsetup, priors, hyperpriors, indice
     y_csd = mar2csd(mar, freq, dt^-1);     # compute cross spectral densities from MAR parameters at specific frequencies freqs, dt^-1 is sampling rate of data
 
     statevals = [v for v in values(initcond)]
+    append!(statevals, zeros(length(unknowns(model)) - length(statevals)))
     f_model = generate_function(model; expression=Val{false})[1]
     f_at(params, t) = states -> f_model(states, params, t)
-    derivatives = par -> jacobian(f_at(addnontunableparams(par, model), t), AutoEnzyme(function_annotation=Enzyme.Const), statevals)
-
-    # jac_fg = generate_jacobian(model, expression = Val{false})[1]   # compute symbolic jacobian.
-    # derivatives = par -> jac_fg(statevals, addnontunableparams(par, model), t)
+    derivatives = par -> jacobian(f_at(addnontunableparams(par, model), t), statevals)
 
     μθ_pr = vecparam(priors.μθ_pr)        # note: μθ_po is posterior and μθ_pr is prior
     Σθ_pr = diagm(vecparam(priors.Σθ_pr))
@@ -482,7 +480,7 @@ function _run_sDCM_iteration!(state::VLState, setup::VLSetup)
     (Πθ_pr, Πλ_pr) = setup.systemmatrices
     Q = setup.Q
 
-    dfdp = ForwardDiff.jacobian(f, μθ_po)
+    dfdp = jacobian(f, μθ_po)
 
     norm_dfdp = opnorm(dfdp, Inf);
     revert = isnan(norm_dfdp) || norm_dfdp > exp(32);

--- a/src/datafitting/spDCM_VL.jl
+++ b/src/datafitting/spDCM_VL.jl
@@ -178,7 +178,7 @@ function csd_approx(freq, derivatives, params, indices)
             Gn[:,j,i] = Gn[:,i,j]
         end
     end
-    S = transferfunction(freq, derivatives, params, indices)   # This is K(freq) in the equations of the spectral DCM paper.
+    S = transferfunction(freq, derivatives, params, indices)   # This is K(ω) in the equations of the spectral DCM paper.
 
     # predicted cross-spectral density
     G = zeros(eltype(S), nfreq, nrr, nrr);
@@ -227,7 +227,7 @@ function csd_approx_lfp(freq, derivatives, params, params_idx)
     return G
 end
 
-@views function csd_mtf(freq, p, derivatives, params, params_idx, modality)   # alongside the above realtes to spm_csd_fmri_mtf.m
+function csd_mtf(freq, p::Int64, derivatives, params, params_idx, modality::String)   # alongside the above realtes to spm_csd_fmri_mtf.m
     if modality == "fMRI"
         G = csd_approx(freq, derivatives, params, params_idx)
         dt = 1/(2*freq[end])
@@ -236,7 +236,7 @@ end
         # But this does not correspond to any equation in the papers nor is it commented in the SPM12 code. NB: Friston conferms that likely it is
         # to make y well behaved.
         mar = csd2mar(G, freq, dt, p-1)
-        y = mar2csd(mar, freq)    
+        y = mar2csd(mar, freq)
     elseif modality == "LFP"
         y = csd_approx_lfp(freq, derivatives, params, params_idx)
     end
@@ -260,7 +260,7 @@ function csd_Q(csd)
             end
         end
     end
-    Q = inv(Q + opnorm(Q, 1)*I/32)   # TODO: MATLAB's and Julia's norm function are different! Reconciliate?
+    Q = inv(Q + opnorm(Q, 1)*I/32)
     return Q
 end
 
@@ -418,7 +418,7 @@ function setup_sDCM(data, model, initcond, csdsetup, priors, hyperpriors, indice
 
     ### Collect prior means and covariances ###
     if haskey(hyperpriors, :Q)
-        Q = hyperpriors[:Q];
+        Q = hyperpriors.Q;
     else
         Q = csd_Q(y_csd);                 # compute functional connectivity prior Q. See Friston etal. 2007 Appendix A
     end
@@ -437,9 +437,9 @@ function setup_sDCM(data, model, initcond, csdsetup, priors, hyperpriors, indice
         -4,                                  # log ascent rate
         [-Inf],                              # free energy
         Float64[],                           # delta free energy
-        hyperpriors[:μλ_pr],                 # metaparameter, initial condition. TODO: why are we not just using the prior mean?
+        hyperpriors.μλ_pr,                   # metaparameter, initial condition. TODO: why are we not just using the prior mean?
         zeros(np),                           # parameter estimation error ϵ_θ
-        [zeros(np), hyperpriors[:μλ_pr]],    # memorize reset state
+        [zeros(np), hyperpriors.μλ_pr],      # memorize reset state
         μθ_pr,                               # parameter posterior mean
         Σθ_pr,                               # parameter posterior covariance
         zeros(np),
@@ -452,8 +452,8 @@ function setup_sDCM(data, model, initcond, csdsetup, priors, hyperpriors, indice
         y_csd,                                # empirical cross-spectral density
         1e-1,                                 # tolerance
         [nr, np, ny, nq, nh],                 # number of parameters, number of data points, number of Qs, number of hyperparameters
-        [μθ_pr, hyperpriors[:μλ_pr]],         # parameter and hyperparameter prior mean
-        [inv(Σθ_pr), hyperpriors[:Πλ_pr]],    # parameter and hyperparameter prior precision matrices
+        [μθ_pr, hyperpriors.μλ_pr],           # parameter and hyperparameter prior mean
+        [inv(Σθ_pr), hyperpriors.Πλ_pr],      # parameter and hyperparameter prior precision matrices
         Q,                                    # components of data precision matrix
         modelparam
     )

--- a/src/datafitting/spDCM_VL.jl
+++ b/src/datafitting/spDCM_VL.jl
@@ -408,19 +408,22 @@ function setup_sDCM(data, model, initcond, csdsetup, priors, hyperpriors, indice
     data = Matrix(data[:, String.(Symbol.(vars))])           # make sure the column order is consistent with the ordering of variables of the model that represent the measurements
     mar = mar_ml(data, mar_order);         # compute MAR from time series y and model order p
     y_csd = mar2csd(mar, freq, dt^-1);     # compute cross spectral densities from MAR parameters at specific frequencies freqs, dt^-1 is sampling rate of data
-    jac_fg = generate_jacobian(model, expression = Val{false})[1]   # compute symbolic jacobian.
-
+    f = generate_function(model; expression=Val{false})[1]
     statevals = [v for v in values(initcond)]
-    derivatives = par -> jac_fg(statevals, addnontunableparams(par, model), t)
+    f_at(params) = states -> f(states, params, 0.0)
+    derivatives = params -> jacobian(f_at(addnontunableparams(params, model)), statevals)
+    Main.foo[] = f, f_at, statevals, model
+    # jac_fg = generate_jacobian(model, expression = Val{false})[1]   # compute symbolic jacobian.
+    # derivatives = par -> jac_fg(statevals, addnontunableparams(par, model), t)
 
-    μθ_pr = vecparam(priors.μθ_pr)   # note: μθ_po is posterior and μθ_pr is prior
+    μθ_pr = vecparam(priors.μθ_pr)        # note: μθ_po is posterior and μθ_pr is prior
     Σθ_pr = diagm(vecparam(priors.Σθ_pr))
 
     ### Collect prior means and covariances ###
     if haskey(hyperpriors, :Q)
         Q = hyperpriors.Q;
     else
-        Q = csd_Q(y_csd);                 # compute functional connectivity prior Q. See Friston etal. 2007 Appendix A
+        Q = csd_Q(y_csd);             # compute functional connectivity prior Q. See Friston etal. 2007 Appendix A
     end
     nq = 1                            # TODO: this is hard-coded, need to make this compliant with csd_Q
     nh = size(Q, 3)                   # number of precision components (this is the same as above, but may differ)

--- a/src/datafitting/spDCM_VL.jl
+++ b/src/datafitting/spDCM_VL.jl
@@ -408,11 +408,12 @@ function setup_sDCM(data, model, initcond, csdsetup, priors, hyperpriors, indice
     data = Matrix(data[:, String.(Symbol.(vars))])           # make sure the column order is consistent with the ordering of variables of the model that represent the measurements
     mar = mar_ml(data, mar_order);         # compute MAR from time series y and model order p
     y_csd = mar2csd(mar, freq, dt^-1);     # compute cross spectral densities from MAR parameters at specific frequencies freqs, dt^-1 is sampling rate of data
-    f = generate_function(model; expression=Val{false})[1]
+
     statevals = [v for v in values(initcond)]
-    f_at(params) = states -> f(states, params, 0.0)
-    derivatives = params -> jacobian(f_at(addnontunableparams(params, model)), statevals)
-    Main.foo[] = f, f_at, statevals, model
+    f_model = generate_function(model; expression=Val{false})[1]
+    f_at(params, t) = states -> f_model(states, params, t)
+    derivatives = par -> jacobian(f_at(addnontunableparams(par, model), t), AutoEnzyme(function_annotation=Enzyme.Const), statevals)
+
     # jac_fg = generate_jacobian(model, expression = Val{false})[1]   # compute symbolic jacobian.
     # derivatives = par -> jac_fg(statevals, addnontunableparams(par, model), t)
 
@@ -481,7 +482,7 @@ function _run_sDCM_iteration!(state::VLState, setup::VLSetup)
     (Πθ_pr, Πλ_pr) = setup.systemmatrices
     Q = setup.Q
 
-    dfdp = jacobian(f, μθ_po)
+    dfdp = ForwardDiff.jacobian(f, μθ_po)
 
     norm_dfdp = opnorm(dfdp, Inf);
     revert = isnan(norm_dfdp) || norm_dfdp > exp(32);
@@ -496,7 +497,7 @@ function _run_sDCM_iteration!(state::VLState, setup::VLSetup)
 
             μθ_po = μθ_pr + ϵ_θ
 
-            dfdp = jacobian(f, μθ_po)
+            dfdp = ForwardDiff.jacobian(f, μθ_po)
 
             # check for stability
             norm_dfdp = opnorm(dfdp, Inf);

--- a/test/datafitting.jl
+++ b/test/datafitting.jl
@@ -36,10 +36,9 @@ using MAT
         push!(A, only(@parameters $symb = a))
     end
 
-    # untune!(A, untunelist)   # list indices of parameters that should be set to tunable=false
     for (i, idx) in enumerate(CartesianIndices(vars["pE"]["A"]))
         if idx[1] == idx[2]
-            add_edge!(g, regions[idx[1]], regions[idx[2]], :weight, -exp(A[i])/2)  # treatement of diagonal elements in SPM12, likely to avoid instabilities of the linear model
+            add_edge!(g, regions[idx[1]], regions[idx[2]], :weight, -exp(A[i])/2)  # treatement of diagonal elements in SPM, likely to avoid instabilities of the linear model
         else
             add_edge!(g, regions[idx[2]], regions[idx[1]], :weight, A[i])
         end
@@ -47,7 +46,7 @@ using MAT
 
     # compose model
     @named neuronmodel = system_from_graph(g, simplify=false)
-    untunelist = Dict()
+    untunelist = Dict()  # dictionary of parameters whose tunable flag may be changed, we do this in dependency of variances that are set to 0 as is done in SPM
     for (i, v) in enumerate(diag(vars["pC"])[1:nrr^2])
         untunelist[A[i]] = v == 0 ? false : true
     end
@@ -81,9 +80,6 @@ using MAT
     csdsetup = (mar_order = 8, freq = freq, dt = dt);
 
     (state, setup) = setup_sDCM(data, neuronmodel, initcond, csdsetup, priors, hyperpriors, indices, pmean, "fMRI");
-
-    # HACK: on machines with very small amounts of RAM, Julia can run out of stack space while compiling the code called in this loop
-    # this should be rewritten to abuse the compiler less, but for now, an easy solution is just to run it with more allocated stack space.
 
     for iter in 1:max_iter
         state.iter = iter
@@ -123,7 +119,7 @@ end
 
     @parameters lnr = 0.0
     @parameters lnτ_ss=0 lnτ_sp=0 lnτ_ii=0 lnτ_dp=0
-    @parameters C=512.0 [tunable = false]    # TODO: SPM12 has this seemingly arbitrary 512 pre-factor in spm_fx_cmc.m. Can we understand why?
+    @parameters C=512.0 [tunable = false]    # TODO: SPM has this seemingly arbitrary 512 pre-factor in spm_fx_cmc.m. Can we understand why?
     for ii = 1:nrr
         region = CanonicalMicroCircuitBlox(;namespace=global_ns, name=Symbol("r$(ii)₊cmc"), 
                                             τ_ss=exp(lnτ_ss)*0.002, τ_sp=exp(lnτ_sp)*0.002, τ_ii=exp(lnτ_ii)*0.016, τ_dp=exp(lnτ_dp)*0.028, 


### PR DESCRIPTION
As we work towards making  Enzyme work for our code this PR uses ForwardDiff to replace the symbolic jacobian which (currently) cannot deal with larger systems without causing stack overflows with an AD jacobian. I've used ForwardDiff for now.

This gives ~20% speed improvement on the fMRI 3 regions test, ~0.4 seconds instead of ~0.5 seconds for 19 iterations.

And we can remove the stack-memory hack to avoid the overflow on machines with non that much RAM.