### PR TITLE
Callback and connection fixes for CS model

### DIFF
--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -130,7 +130,7 @@ function merge_discrete_callbacks(cbs)
     cbs_symbolic = Pair[]
 
     for cb in cbs
-        if last(cb) isa ModelingToolkit.FunctionalAffect
+        if last(cb) isa Tuple
             push!(cbs_functional, cb)
         else
             push!(cbs_symbolic, cb)
@@ -138,7 +138,7 @@ function merge_discrete_callbacks(cbs)
     end
 
     conditions = unique(first.(cbs_symbolic))
-
+    
     for c in conditions
         idxs = findall(cb -> first(cb) == c, cbs_symbolic)
         affects = mapreduce(last, vcat, cbs_symbolic[idxs])

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -48,7 +48,7 @@ end
 get_system(g::MetaDiGraph) = get_system.(get_bloxs(g))
 
 get_dynamics_bloxs(blox) = [blox]
-get_dynamics_bloxs(blox::CompositeBlox) = get_parts(blox)
+get_dynamics_bloxs(blox::CompositeBlox) = mapreduce(get_dynamics_bloxs, vcat, get_parts(blox))
 
 flatten_graph(g::MetaDiGraph) = mapreduce(get_dynamics_bloxs, vcat, get_bloxs(g))
 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -125,6 +125,29 @@ function LIF_spike_affect!(integ, u, p, ctx)
     end
 end
 
+function merge_discrete_callbacks(cbs)
+    cbs_functional = Pair[]
+    cbs_symbolic = Pair[]
+
+    for cb in cbs
+        if last(cb) isa ModelingToolkit.FunctionalAffect
+            push!(cbs_functional, cb)
+        else
+            push!(cbs_symbolic, cb)
+        end
+    end
+
+    conditions = unique(first.(cbs_symbolic))
+
+    for c in conditions
+        idxs = findall(cb -> first(cb) == c, cbs_symbolic)
+        affects = mapreduce(last, vcat, cbs_symbolic[idxs])
+        push!(cbs_functional, c => affects)
+    end
+
+    return cbs_functional
+end
+
 generate_discrete_callbacks(blox, ::Connector; t_block = missing) = []
 
 function generate_discrete_callbacks(blox::AbstractSpikeSource, bc::Connector; t_block = missing)
@@ -231,10 +254,11 @@ function generate_discrete_callbacks(g::MetaDiGraph, bc::Connector, eqs::Abstrac
     cbs = mapreduce(vcat, bloxs) do blox
         generate_discrete_callbacks(blox, bc; t_block)
     end
-    
+    cbs_merged = merge_discrete_callbacks(cbs)
+
     cbs_connections = generate_discrete_callbacks(bc, eqs; t_block)
 
-    return vcat(cbs, cbs_connections)
+    return vcat(cbs_merged, cbs_connections)
 end
 
 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -137,14 +137,33 @@ function merge_discrete_callbacks(cbs::AbstractVector)
         end
     end
 
+    # We need to take care of the edge case where the same condition appears multiple times 
+    # with the same affect. If we merge them using unique(affects) then the affect will apply only once.
+    # But it could be the case that we want this affect to apply as many times as it appears in duplicate callbacks,
+    # e.g. because it is a spike affect coming from different sources that happen to spike exactly at the same condition. 
     conditions = unique(first.(cbs_symbolic))
-    
     for c in conditions
         idxs = findall(cb -> first(cb) == c, cbs_symbolic)
-        affects = unique(mapreduce(last, vcat, cbs_symbolic[idxs]))
-        push!(cbs_functional, c => affects)
-    end
+        affects = mapreduce(last, vcat, cbs_symbolic[idxs])
+        idxs = eachindex(affects)
 
+        affects_to_merge = Equation[]
+        for (i, aff) in enumerate(affects)
+            idxs_rest = setdiff(idxs, i)
+            if isnothing(findfirst(x -> aff == x, affects[idxs_rest]))
+                # If the affect has no duplicate then accumulate it for merging.
+                push!(affects_to_merge, aff)
+            else
+                # If the affect has a duplicate then add them as separate callbacks
+                # so that each one triggers as intended. 
+                push!(cbs_functional, c => [aff])
+            end
+        end
+        if !isempty(affects_to_merge)
+            push!(cbs_functional, c => affects_to_merge)
+        end
+    end
+   
     return cbs_functional
 end
 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -125,7 +125,7 @@ function LIF_spike_affect!(integ, u, p, ctx)
     end
 end
 
-function merge_discrete_callbacks(cbs)
+function merge_discrete_callbacks(cbs::AbstractVector)
     cbs_functional = Pair[]
     cbs_symbolic = Pair[]
 
@@ -254,7 +254,7 @@ function generate_discrete_callbacks(g::MetaDiGraph, bc::Connector, eqs::Abstrac
     cbs = mapreduce(vcat, bloxs) do blox
         generate_discrete_callbacks(blox, bc; t_block)
     end
-    cbs_merged = merge_discrete_callbacks(cbs)
+    cbs_merged = merge_discrete_callbacks(to_vector(cbs))
 
     cbs_connections = generate_discrete_callbacks(bc, eqs; t_block)
 

--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -141,7 +141,7 @@ function merge_discrete_callbacks(cbs)
     
     for c in conditions
         idxs = findall(cb -> first(cb) == c, cbs_symbolic)
-        affects = mapreduce(last, vcat, cbs_symbolic[idxs])
+        affects = unique(mapreduce(last, vcat, cbs_symbolic[idxs]))
         push!(cbs_functional, c => affects)
     end
 

--- a/src/blox/connections.jl
+++ b/src/blox/connections.jl
@@ -704,6 +704,19 @@ function Connector(
 end
 
 function Connector(
+    blox_src::Union{CorticalBlox,STN,Thalamus},
+    blox_dest::Union{GPi, GPe};
+    kwargs...
+)
+    neurons_dest = get_inh_neurons(blox_dest)
+    neurons_src = get_exci_neurons(blox_src)
+
+    conn = hypergeometric_connections(neurons_src, neurons_dest, nameof(blox_src), nameof(blox_dest); kwargs...)
+
+    return conn
+end
+
+function Connector(
     blox_src::Union{Striatum, GPi, GPe},
     blox_dest::Union{CorticalBlox,STN,Thalamus};
     kwargs...

--- a/src/blox/sources.jl
+++ b/src/blox/sources.jl
@@ -182,7 +182,7 @@ struct PoissonSpikeTrain{N} <: AbstractSpikeSource
     rng
 end
 
-function PoissonSpikeTrain(rate::Union{AbstractVector{N}, N}, tspan::Union{AbstractVector{T}, T}; name, namespace=nothing, N_trains=1, prob_dt=0.01, rng=MersenneTwister(1234)) where {N <: Number, T <: Tuple}
+function PoissonSpikeTrain(rate::Union{AbstractVector{N}, N}, tspan::Union{AbstractVector{T}, T}; name, namespace=nothing, N_trains=1, prob_dt=0.01, rng=Random.GLOBAL_RNG) where {N <: Number, T <: Tuple}
     rate = to_vector(rate)
     tspan = to_vector(tspan)
 
@@ -191,7 +191,7 @@ function PoissonSpikeTrain(rate::Union{AbstractVector{N}, N}, tspan::Union{Abstr
     PoissonSpikeTrain(name, namespace, N_trains, rate, tspan, prob_dt, rng)
 end
 
-function PoissonSpikeTrain(rate_sampling::NamedTuple, tspan::Tuple; name, namespace=nothing, N_trains=1, prob_dt=0.01, rng=MersenneTwister(1234))     
+function PoissonSpikeTrain(rate_sampling::NamedTuple, tspan::Tuple; name, namespace=nothing, N_trains=1, prob_dt=0.01, rng=Random.GLOBAL_RNG)     
     
     PoissonSpikeTrain(name, namespace, N_trains, rate_sampling, tspan, prob_dt, rng)
 end

--- a/test/GraphDynamicsTests/test_suite.jl
+++ b/test/GraphDynamicsTests/test_suite.jl
@@ -647,6 +647,7 @@ function lif_exci_inh_tests(;tspan=(0.0, 20.0), rtol=1e-8)
     
 ## Describe what the local variables you define are for
     global_ns = :g ## global name for the circuit. All components should be inside this namespace.
+    rng = MersenneTwister(1234)
 
     spike_rate = 2.4 ## spikes / ms
 
@@ -677,10 +678,10 @@ function lif_exci_inh_tests(;tspan=(0.0, 20.0), rtol=1e-8)
     spike_rate_B = (distribution=Normal(μ_B, σ), dt=dt_spike_rate) # spike rate distribution for selective population B
 
     # Blox definitions
-    @named background_input  = PoissonSpikeTrain(spike_rate, tspan; namespace = global_ns, N_trains=1);
-    @named background_input2 = PoissonSpikeTrain(spike_rate + 0.1, tspan; namespace = global_ns, N_trains=1);
-    @named stim_A = PoissonSpikeTrain(spike_rate_A, tspan; namespace = global_ns);
-    @named stim_B = PoissonSpikeTrain(spike_rate_B, tspan; namespace = global_ns);
+    @named background_input  = PoissonSpikeTrain(spike_rate, tspan; namespace = global_ns, N_trains=1, rng);
+    @named background_input2 = PoissonSpikeTrain(spike_rate + 0.1, tspan; namespace = global_ns, N_trains=1, rng);
+    @named stim_A = PoissonSpikeTrain(spike_rate_A, tspan; namespace = global_ns, rng);
+    @named stim_B = PoissonSpikeTrain(spike_rate_B, tspan; namespace = global_ns, rng);
 
     @named n1 = LIFExciNeuron()
     @named n2 = LIFExciNeuron()
@@ -701,7 +702,7 @@ function decision_making_test(;tspan=(0.0, 20.0), rtol=1e-5, N_E=24)
     
     ## Describe what the local variables you define are for
     global_ns = :g ## global name for the circuit. All components should be inside this namespace.
-
+    rng = MersenneTwister(1234)
     spike_rate = 2.4 ## spikes / ms
 
     f = 0.15 ## ratio of selective excitatory to non-selective excitatory neurons
@@ -731,10 +732,10 @@ function decision_making_test(;tspan=(0.0, 20.0), rtol=1e-5, N_E=24)
     spike_rate_B = (distribution=Normal(μ_B, σ), dt=dt_spike_rate) # spike rate distribution for selective population B
 
     # Blox definitions
-    @named background_input = PoissonSpikeTrain(spike_rate, tspan; namespace = global_ns, N_trains=1);
+    @named background_input = PoissonSpikeTrain(spike_rate, tspan; namespace = global_ns, N_trains=1, rng);
 
-    @named stim_A = PoissonSpikeTrain(spike_rate_A, tspan; namespace = global_ns);
-    @named stim_B = PoissonSpikeTrain(spike_rate_B, tspan; namespace = global_ns);
+    @named stim_A = PoissonSpikeTrain(spike_rate_A, tspan; namespace = global_ns, rng);
+    @named stim_B = PoissonSpikeTrain(spike_rate_B, tspan; namespace = global_ns, rng);
 
     @named n_A = LIFExciCircuitBlox(; namespace = global_ns, N_neurons = N_E_selective, weight = w₊, exci_scaling_factor, inh_scaling_factor);
     @named n_B = LIFExciCircuitBlox(; namespace = global_ns, N_neurons = N_E_selective, weight = w₊, exci_scaling_factor, inh_scaling_factor) ;


### PR DESCRIPTION
- Adds missing connection rule.
- Fixes an issue with missing `spikes_window ~ 0` reset callbacks due to incorrect `flatten_graph` (basically `get_dynamics_bloxs`).
- Merges discrete callbacks with common conditions into one. This could improve runtime. 