### PR TITLE
Fix `get_components` for `Composite` with `AbstractDiscrete` components

### DIFF
--- a/src/Neurographs.jl
+++ b/src/Neurographs.jl
@@ -46,10 +46,7 @@ end
 
 get_system(g::MetaDiGraph) = get_system.(get_bloxs(g))
 
-get_dynamics_bloxs(blox) = [blox]
-get_dynamics_bloxs(blox::CompositeBlox) = mapreduce(get_dynamics_bloxs, vcat, get_parts(blox))
-
-flatten_graph(g::MetaDiGraph) = mapreduce(get_dynamics_bloxs, vcat, get_bloxs(g))
+flatten_graph(g::MetaDiGraph) = mapreduce(get_components, vcat, get_bloxs(g))
 
 function connectors_from_graph(g::MetaDiGraph)
     conns = reduce(vcat, get_connectors.(get_bloxs(g)))

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -78,9 +78,10 @@ end
 get_parts(blox::CompositeBlox) = blox.parts
 get_parts(blox::Union{AbstractBlox, ObserverBlox}) = blox
 
-get_components(blox::CompositeBlox) = mapreduce(x -> get_components(x), vcat, get_parts(blox))
-get_components(blox::Vector{<:AbstractBlox}) = mapreduce(x -> get_components(x), vcat, blox)
-get_components(blox::Union{NeuralMassBlox, AbstractNeuronBlox}) = [blox]
+get_dynamics_components(blox::AbstractDiscrete) = []
+get_dynamics_components(blox::Union{NeuralMassBlox, AbstractNeuronBlox}) = [blox]
+get_dynamics_components(blox::CompositeBlox) = mapreduce(get_dynamics_components, vcat, get_parts(blox))
+get_dynamics_components(blox::Vector{<:AbstractBlox}) = mapreduce(get_dynamics_components, vcat, blox)
 
 get_neuron_color(n::AbstractExciNeuronBlox) = "blue"
 get_neuron_color(n::AbstractInhNeuronBlox) = "red"

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -78,6 +78,10 @@ end
 get_parts(blox::CompositeBlox) = blox.parts
 get_parts(blox::Union{AbstractBlox, ObserverBlox}) = blox
 
+get_components(blox::CompositeBlox) = mapreduce(get_components, vcat, get_parts(blox))
+get_components(blox::Vector{<:AbstractBlox}) = mapreduce(get_components, vcat, blox)
+get_components(blox) = [blox]
+
 get_dynamics_components(blox::AbstractDiscrete) = []
 get_dynamics_components(blox::Union{NeuralMassBlox, AbstractNeuronBlox}) = [blox]
 get_dynamics_components(blox::CompositeBlox) = mapreduce(get_dynamics_components, vcat, get_parts(blox))

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -572,7 +572,7 @@ end
 function state_timeseries(cb::Union{CompositeBlox, AbstractVector{<:AbstractBlox}},
                           sol::SciMLBase.AbstractSolution, state::String; ts=nothing)
     
-    neurons = get_components(cb)
+    neurons = get_dynamics_components(cb)
     state_names = map(neuron -> Symbol(namespaced_nameof(neuron), "₊", state), neurons)
 
     if isnothing(ts)

--- a/src/blox/discrete.jl
+++ b/src/blox/discrete.jl
@@ -29,9 +29,6 @@ struct Matrisome <: AbstractDiscrete
     end
 end
 
-
-
-
 struct Striosome <: AbstractDiscrete
     system
     namespace


### PR DESCRIPTION
Makes a clearer distinction between two getter functions : 

- `get_components` returns all parts of a composite
- `get_dynamics_components` returns only the parts of a composite that have differential equations in them, e.g. neurons and masses and not discrete bloxs.

Replaces `get_components` with `get_dynamics_components` in `state_timeseries` to avoid any discrete bloxs in downstream calculations, e..g meanfield.