### PR TITLE
Replace `paramscoping` with `@paramscoping`

### DIFF
--- a/docs/src/dev_tutorials/graph_dynamics_interop.jl
+++ b/docs/src/dev_tutorials/graph_dynamics_interop.jl
@@ -12,7 +12,7 @@ using Neuroblox, ModelingToolkit, GraphDynamics
 using Neuroblox.GraphDynamicsInterop
 
 using Neuroblox: 
-    paramscoping,
+    @paramscoping,
     NeuralMassBlox,
     get_namespaced_sys,
     generate_weight_param,
@@ -37,8 +37,7 @@ struct VanDerPol <: NeuralMassBlox
     system
     namespace
     function VanDerPol(; name, namespace=nothing, θ=1.0, ϕ=0.1)
-        p = paramscoping(θ=θ, ϕ=ϕ)
-        θ, ϕ = p
+        p = @paramscoping θ ϕ
         sts = @variables begin
             ## our regular dynamical variables
             x(t)=0.0 
@@ -305,13 +304,13 @@ struct DBS <: Neuroblox.StimulusBlox
             t -> Neuroblox.square(t, frequency_khz, amplitude, offset, start_time, pulse_width, smooth)
         end
     
-        p = Neuroblox.paramscoping(
-            tunable=false;
-            frequency=frequency,
-            amplitude=amplitude,
-            pulse_width=pulse_width,
-            offset=offset,
-            start_time=start_time
+        p = @paramscoping(
+            tunable=false,
+            frequency,
+            amplitude,
+            pulse_width,
+            offset,
+            start_time
         )
     
         sts = @variables u(t) [output = true]

--- a/src/Neuroblox.jl
+++ b/src/Neuroblox.jl
@@ -91,6 +91,29 @@ abstract type BloxConnectMultiComplex <: BloxConnection end
 # dictionary type for Blox parameters
 Para_dict = Dict{Symbol, Union{<: Real, Num}}
 
+
+"""
+    @paramscoping(tunable=true, args...)
+    
+Scope arguments that are already a symbolic model parameter thereby keep the correct namespace 
+and make those that are not yet symbolic a symbol.
+"""
+macro paramscoping(arg1, args::Symbol...)
+    if Base.isexpr(arg1, :(=)) && arg1.args[1] == :tunable
+        istunable = arg1.args[2]
+    elseif arg1 isa Symbol
+        args = (arg1, args...)
+        istunable = true
+    else
+        error("Invalid first argument to @paramscoping. Must be either tunable=istunable, or a Symbol.")
+    end
+    argsnew = (Iterators.flatten ∘ Iterators.map)(args) do arg
+        (:($arg = $arg isa Num ? ($ParentScope($arg)) : $arg), :([tunable=$istunable]))
+    end
+    esc(:($ModelingToolkit.@parameters($(argsnew...),)))
+end
+
+
 include("utilities/spectral_tools.jl")
 include("utilities/learning_tools.jl")
 include("utilities/bold_methods.jl")

--- a/src/blox/DBS_sources.jl
+++ b/src/blox/DBS_sources.jl
@@ -48,14 +48,7 @@ function DBS(;
         t -> square(t, frequency_khz, amplitude, offset, start_time, pulse_width, smooth)
     end
 
-    p = paramscoping(
-        tunable=false;
-        frequency=frequency,
-        amplitude=amplitude,
-        pulse_width=pulse_width,
-        offset=offset,
-        start_time=start_time
-    )
+    p = @paramscoping tunable=false frequency amplitude pulse_width offset start_time
 
     sts = @variables u(t) [output = true]
     eqs = [u ~ stimulus(t)]
@@ -140,18 +133,18 @@ function ProtocolDBS(;
         )
     end
 
-    p = paramscoping(
-        tunable=false;
-        frequency=frequency,
-        amplitude=amplitude,
-        pulse_width=pulse_width,
-        offset=offset,
-        smooth=smooth,
-        start_time=start_time,
-        pulses_per_burst=pulses_per_burst,
-        bursts_per_block=bursts_per_block,
-        pre_block_time=pre_block_time,
-        inter_burst_time=inter_burst_time,
+    p = @paramscoping(
+        tunable=false,
+        frequency,
+        amplitude,
+        pulse_width,
+        offset,
+        smooth,
+        start_time,
+        pulses_per_burst,
+        bursts_per_block,
+        pre_block_time,
+        inter_burst_time
     )
 
     sts = @variables u(t) [output = true]

--- a/src/blox/blox_utilities.jl
+++ b/src/blox/blox_utilities.jl
@@ -16,6 +16,7 @@ end
     Keyword arguments are used, because parameter definition require names, not just values.
 """
 function paramscoping(;tunable=true, kwargs...)
+    @warn "paramscoping is deprecated" 
     paramlist = []
     for (kw, v) in kwargs
         if v isa Num

--- a/src/blox/canonicalmicrocircuit.jl
+++ b/src/blox/canonicalmicrocircuit.jl
@@ -8,9 +8,7 @@ mutable struct JansenRitSPM <: NeuralMassBlox
     system
     namespace
     function JansenRitSPM(;name, namespace=nothing, τ=1.0, r=2.0/3.0)
-        p = paramscoping(τ=τ, r=r)
-        τ, r = p
-
+        p = @paramscoping τ r
         sts    = @variables x(t)=1.0 [output=true] y(t)=1.0 jcn(t) [input=true]
         eqs    = [D(x) ~ y - ((2/τ)*x),
                   D(y) ~ -x/(τ*τ) + jcn/τ]

--- a/src/blox/neural_mass.jl
+++ b/src/blox/neural_mass.jl
@@ -111,7 +111,7 @@ struct HarmonicOscillator <: NeuralMassBlox
 
     function HarmonicOscillator(;name, namespace=nothing, ω=25*(2*pi)*0.001, ζ=1.0, k=625*(2*pi), h=35.0)
         # p = progress_scope(ω, ζ, k, h)
-        p = paramscoping(ω=ω, ζ=ζ, k=k, h=h)
+        p = @paramscoping ω ζ k h
         sts    = @variables x(t)=1.0 [output=true] y(t)=1.0 jcn(t) [input=true]
         ω, ζ, k, h = p
         eqs    = [D(x) ~ y-(2*ω*ζ*x)+ k*(2/π)*(atan((jcn)/h))
@@ -169,8 +169,8 @@ struct JansenRit <: NeuralMassBlox
         r = isnothing(r) ? (cortical ? 0.15 : 0.1) : r
 
         # p = progress_scope(τ, H, λ, r)
-        p = paramscoping(τ=τ, H=H, λ=λ, r=r)
-        τ, H, λ, r = p
+        p = @paramscoping τ H λ r
+        
         if !delayed
             sts = @variables x(t)=1.0 [output=true] y(t)=1.0 jcn(t) [input=true] 
             eqs = [D(x) ~ y - ((2/τ)*x),
@@ -232,8 +232,7 @@ struct WilsonCowan <: NeuralMassBlox
                         η=1.0
     )
         # p = progress_scope(τ_E, τ_I, a_E, a_I, c_EE, c_IE, c_EI, c_II, θ_E, θ_I, η)
-        p = paramscoping(τ_E=τ_E, τ_I=τ_I, a_E=a_E, a_I=a_I, c_EE=c_EE, c_IE=c_IE, c_EI=c_EI, c_II=c_II, θ_E=θ_E, θ_I=θ_I, η=η)
-        τ_E, τ_I, a_E, a_I, c_EE, c_IE, c_EI, c_II, θ_E, θ_I, η = p
+        p = @paramscoping τ_E τ_I a_E a_I c_EE c_IE c_EI c_II θ_E θ_I η
         sts = @variables E(t)=1.0 [output=true] I(t)=1.0 jcn(t) [input=true] #P(t)=0.0
         eqs = [D(E) ~ -E/τ_E + 1/(1 + exp(-a_E*(c_EE*E - c_IE*I - θ_E + η*(jcn)))), #old form: D(E) ~ -E/τ_E + 1/(1 + exp(-a_E*(c_EE*E - c_IE*I - θ_E + P + η*(jcn)))),
                D(I) ~ -I/τ_I + 1/(1 + exp(-a_I*(c_EI*E - c_II*I - θ_I)))]
@@ -300,8 +299,7 @@ struct LarterBreakspear <: NeuralMassBlox
                         C=0.35
     )
         # p = progress_scope(C, δ_VZ, T_Ca, δ_Ca, g_Ca, V_Ca, T_K, δ_K, g_K, V_K, T_Na, δ_Na, g_Na, V_Na, V_L, g_L, V_T, Z_T, Q_Vmax, Q_Zmax, IS, a_ee, a_ei, a_ie, a_ne, a_ni, b, τ_K, ϕ,r_NMDA)
-        p = paramscoping(C=C, δ_VZ=δ_VZ, T_Ca=T_Ca, δ_Ca=δ_Ca, g_Ca=g_Ca, V_Ca=V_Ca, T_K=T_K, δ_K=δ_K, g_K=g_K, V_K=V_K, T_Na=T_Na, δ_Na=δ_Na, g_Na=g_Na, V_Na=V_Na, V_L=V_L, g_L=g_L, V_T=V_T, Z_T=Z_T, Q_Vmax=Q_Vmax, Q_Zmax=Q_Zmax, IS=IS, a_ee=a_ee, a_ei=a_ei, a_ie=a_ie, a_ne=a_ne, a_ni=a_ni, b=b, τ_K=τ_K, ϕ=ϕ, r_NMDA=r_NMDA)
-        C, δ_VZ, T_Ca, δ_Ca, g_Ca, V_Ca, T_K, δ_K, g_K, V_K, T_Na, δ_Na, g_Na,V_Na, V_L, g_L, V_T, Z_T, Q_Vmax, Q_Zmax, IS, a_ee, a_ei, a_ie, a_ne, a_ni, b, τ_K, ϕ, r_NMDA = p
+        p = @paramscoping C δ_VZ T_Ca δ_Ca g_Ca V_Ca T_K δ_K g_K V_K T_Na δ_Na g_Na V_N V_L g_L V_T Z_T Q_Vmax Q_Zmax IS a_ee a_ei a_ie a_ne a_ni b τ_K ϕ r_NMDA
         
         sts = @variables V(t)=0.5 Z(t)=0.5 W(t)=0.5 jcn(t) [input=true] Q_V(t) [output=true] Q_Z(t) m_Ca(t) m_Na(t) m_K(t)
 
@@ -387,8 +385,7 @@ struct Generic2dOscillator <: NeuralMassBlox
                         γ=6e-2,
                         bn=0.02,
     )
-        p = paramscoping(τ=τ, a=a,b=b,c=c,d=d,e=e,f=f,g=g,α=α,β=β,γ=γ)
-        τ,a,b,c,d,e,f,g,α,β,γ = p
+        p = @paramscoping τ a b c d e f g α β γ
         
         sts = @variables V(t)=0.0 [output = true] W(t)=1.0 jcn(t) [input=true]
         @brownian w v
@@ -458,8 +455,7 @@ struct KuramotoOscillator{IsNoisy} <: NeuralMassBlox
         end
     end
     function KuramotoOscillator{Noisy}(;name, namespace=nothing, ω=249.0, ζ=5.92)
-        p = paramscoping(ω=ω, ζ=ζ)
-        ω, ζ = p
+        p = @paramscoping ω ζ
         sts = @variables θ(t)=0.0 [output = true] jcn(t) [input=true]
         @brownian w
         eqs = [D(θ) ~ ω + jcn + ζ*w]
@@ -467,8 +463,7 @@ struct KuramotoOscillator{IsNoisy} <: NeuralMassBlox
         new{Noisy}(p, sys, namespace)
     end
     function KuramotoOscillator{NonNoisy}(;name, namespace=nothing, ω=249.0)
-        p = paramscoping(ω=ω)
-        ω = p[1]
+        p = @paramscoping ω
         sts = @variables θ(t)=0.0 [output = true] jcn(t) [input=true]
         eqs = [D(θ) ~ ω + jcn]
         sys = System(eqs, t, sts, p; name=name)
@@ -527,8 +522,7 @@ struct NGNMM_Izh{IsNoisy} <: NeuralMassBlox
 
     end
     function NGNMM_Izh{NonNoisy}(; name, namespace=nothing, Δ=0.02, α=0.6215, gₛ=1.2308, η̄=0.12, I_ext=0.0, eᵣ=1.0, a=0.0077, b=-0.0062, wⱼ=0.0189, sⱼ=1.2308, τₛ=2.6, κ=1.0)
-        p = paramscoping(Δ=Δ, α=α, gₛ=gₛ, η̄=η̄, I_ext=I_ext, eᵣ=eᵣ, a=a, b=b, wⱼ=wⱼ, sⱼ=sⱼ, κ=κ)
-        Δ, α, gₛ, η̄, I_ext, eᵣ, a, b, wⱼ, sⱼ, κ = p
+        p = @paramscoping Δ α gₛ η̄ I_ext eᵣ a b wⱼ sⱼ κ
         sts = @variables r(t)=0.0 V(t)=0.0 w(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
         eqs = [ D(r) ~ Δ/π + 2*r*V - (α+gₛ*s)*r,
                 D(V) ~ V^2 - α*V - w + η̄ + I_ext + gₛ*s*κ*(eᵣ - V) + jcn - (π*r)^2,
@@ -539,8 +533,7 @@ struct NGNMM_Izh{IsNoisy} <: NeuralMassBlox
         new(p, sys, namespace)
     end
     function NGNMM_Izh{Noisy}(; name, namespace=nothing, Δ=0.02, α=0.6215, gₛ=1.2308, η̄=0.12, I_ext=0.0, eᵣ=1.0, a=0.0077, b=-0.0062, wⱼ=0.0189, sⱼ=1.2308, τₛ=2.6, κ=1.0, ζ=0.0)
-        p = paramscoping(Δ=Δ, α=α, gₛ=gₛ, η̄=η̄, I_ext=I_ext, eᵣ=eᵣ, a=a, b=b, wⱼ=wⱼ, sⱼ=sⱼ, τₛ=τₛ, κ=κ, ζ=ζ)
-        Δ, α, gₛ, η̄, I_ext, eᵣ, a, b, wⱼ, sⱼ, τₛ, κ, ζ = p
+        p = @paramscoping Δ α gₛ η̄ I_ext eᵣ a b wⱼ sⱼ τₛ κ ζ
         sts = @variables r(t)=0.0 V(t)=0.0 w(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
         @brownian ξ
         eqs = [ D(r) ~ Δ/π + 2*r*V - (α+gₛ*s)*r,
@@ -594,8 +587,7 @@ struct NGNMM_QIF{IsNoisy} <: NeuralMassBlox
     end
 
     function NGNMM_QIF{NonNoisy}(; name, namespace=nothing, Δ=1.0, τₘ=20.0, H=1.3, I_ext=0.0, ω=0.0, J_internal=8.0)
-        p = paramscoping(Δ=Δ, τₘ=τₘ, H=H, I_ext=I_ext, J_internal=J_internal)
-        Δ, τₘ, H, I_ext, J_internal = p
+        p = @paramscoping(Δ τₘ H I_ext J_internal
         sts = @variables r(t)=0.0 [output=true] V(t)=0.0 jcn(t) [input=true]
         eqs = [D(r) ~ Δ/(π*τₘ^2) + 2*r*V/τₘ,
                D(V) ~ (V^2 + H + I_ext*sin(ω*t))/τₘ - τₘ*(π*r)^2 + J_internal*r  + jcn]
@@ -605,8 +597,7 @@ struct NGNMM_QIF{IsNoisy} <: NeuralMassBlox
     end
 
     function NGNMM_QIF{Noisy}(; name, namespace=nothing, Δ=1.0, τₘ=20.0, H=1.3, I_ext=0.0, ω=0.0, J_internal=8.0, A=0.0)
-        p = paramscoping(Δ=Δ, τₘ=τₘ, H=H, I_ext=I_ext, J_internal=J_internal)
-        Δ, τₘ, H, I_ext, J_internal = p
+        p = @paramscoping Δ τₘ H I_ext J_internal
         sts = @variables r(t)=0.0 [output=true] V(t)=0.0 jcn(t) [input=true]
         @brownian ξ
         eqs = [D(r) ~ Δ/(π*τₘ^2) + 2*r*V/τₘ,
@@ -630,8 +621,7 @@ struct VanDerPol{IsNoisy} <: NeuralMassBlox
         end
     end
     function VanDerPol{Noisy}(; name, namespace=nothing, θ=1.0, ϕ=0.1)
-        p = paramscoping(θ=θ, ϕ=ϕ)
-        θ, ϕ = p
+        p = @paramscoping θ ϕ
         sts = @variables x(t)=0.0 [output=true] y(t)=0.0 jcn(t) [input=true]
         @brownian ξ
 
@@ -642,8 +632,7 @@ struct VanDerPol{IsNoisy} <: NeuralMassBlox
         new{Noisy}(p, sys, namespace)
     end
     function VanDerPol{NonNoisy}(; name, namespace=nothing, θ=1.0)
-        p = paramscoping(θ=θ)
-        θ = p[1]
+        p = @paramscoping θ
         sts = @variables x(t)=0.0 [output=true] y(t)=0.0 jcn(t) [input=true]
         
         eqs = [D(x) ~ y,

--- a/src/blox/neuron_models.jl
+++ b/src/blox/neuron_models.jl
@@ -550,8 +550,7 @@ struct IFNeuron <: AbstractNeuronBlox
 					   θ = -50.0,
 					   Eₘ= -70.0,
 					   I_in=0)
-		p = paramscoping(C=C, θ=θ, Eₘ=Eₘ, I_in=I_in)
-		C, θ, Eₘ, I_in = p
+		p = @paramscoping C θ Eₘ I_in
 		sts = @variables V(t)=-70.00 [output=true] jcn(t) [input=true]
 		eqs = [D(V) ~ (I_in + jcn)/C]
 		ev = (V >= θ) => [V~Eₘ]
@@ -611,8 +610,7 @@ struct LIFNeuron <: AbstractNeuronBlox
 					   E_syn=-70.0,
 					   G_syn=0.002,
 					   I_in=0.0)
-		p = paramscoping(C=C, Eₘ=Eₘ, Rₘ=Rₘ, τ=τ, θ=θ, E_syn=E_syn, G_syn=G_syn, I_in=I_in)
-		C, Eₘ, Rₘ, τ, θ, E_syn, G_syn, I_in = p
+		p = @paramscoping C Eₘ Rₘ τ θ E_syn G_syn I_in
 		sts = @variables V(t)=-70.00 G(t)=0.0 [output=true] jcn(t) [input=true]
 		eqs = [ D(V) ~ (-(V-Eₘ)/Rₘ + I_in + jcn)/C,
 				D(G)~(-1/τ)*G]
@@ -786,8 +784,7 @@ struct QIFNeuron <: AbstractNeuronBlox
 						Eₘ=0.0,
 						Vᵣₑₛ=-70.0,
 						θ=25.0)
-		p = paramscoping(C=C, Rₘ=Rₘ, E_syn=E_syn, G_syn=G_syn, τ₁=τ₁, τ₂=τ₂, I_in=I_in, Eₘ=Eₘ, Vᵣₑₛ=Vᵣₑₛ, θ=θ)
-		C, Rₘ, E_syn, G_syn, τ₁, τ₂, I_in, Eₘ, Vᵣₑₛ, θ = p
+		p = @paramscoping C Rₘ E_syn G_syn τ₁ τ₂ I_in Eₘ Vᵣₑₛ θ
 		sts = @variables V(t)=-70.0 G(t)=0.0 [output=true] z(t)=0.0 jcn(t) [input=true]
 		eqs = [ D(V) ~ ((V-Eₘ)^2/(Rₘ^2)+I_in+jcn)/C,
 		 		D(G)~(-1/τ₂)*G + z,
@@ -832,8 +829,7 @@ struct IzhikevichNeuron <: AbstractNeuronBlox
 							   gₛ=1.2308,
 							   eᵣ=1.0,
 							   τ=2.6)
-		p = paramscoping(α=α, η=η, a=a, b=b, θ=θ, vᵣ=vᵣ, wⱼ=wⱼ, sⱼ=sⱼ, gₛ=gₛ, eᵣ=eᵣ, τ=τ)
-		α, η, a, b, θ, vᵣ, wⱼ, sⱼ, gₛ, eᵣ, τ = p
+		p = @paramscoping α η a b θ vᵣ wⱼ sⱼ gₛ eᵣ τ
 		sts = @variables V(t)=0.0 w(t)=0.0 G(t)=0.0 [output=true] z(t)=0.0 jcn(t) [input=true]
 		eqs = [ D(V) ~ V*(V-α) - w + η + jcn,
 				D(w) ~ a*(b*V - w),

--- a/src/blox/ping_neuron_examples.jl
+++ b/src/blox/ping_neuron_examples.jl
@@ -52,8 +52,7 @@ struct PINGNeuronExci <: AbstractPINGNeuron
                              I_ext=0.0,
                              τ_R=0.2,
                              τ_D=2.0)
-        p = paramscoping(C=C, g_Na=g_Na, V_Na=V_Na, g_K=g_K, V_K=V_K, g_L=g_L, V_L=V_L, I_ext=I_ext, τ_R=τ_R, τ_D=τ_D)
-        C, g_Na, V_Na, g_K, V_K, g_L, V_L, I_ext, τ_R, τ_D = p
+        p = @paramscoping C g_Na V_Na g_K V_K g_L V_L I_ext τ_R τ_D
         sts = @variables V(t)=0.0 n(t)=0.0 h(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
         
         a_m(v) = 0.32*(v+54.0)/(1.0 - exp(-(v+54.0)/4.0))
@@ -126,8 +125,7 @@ struct PINGNeuronInhib <: AbstractPINGNeuron
                              I_ext=0.0,
                              τ_R=0.5,
                              τ_D=10.0)
-        p = paramscoping(C=C, g_Na=g_Na, V_Na=V_Na, g_K=g_K, V_K=V_K, g_L=g_L, V_L=V_L, I_ext=I_ext, τ_R=τ_R, τ_D=τ_D)
-        C, g_Na, V_Na, g_K, V_K, g_L, V_L, I_ext, τ_R, τ_D = p
+        p = @paramscoping C g_Na V_Na g_K V_K g_L V_L I_ext τ_R τ_D
         sts = @variables V(t)=0.0 n(t)=0.0 h(t)=0.0 s(t)=0.0 [output=true] jcn(t) [input=true]
 
         a_m(v) = 0.1*(v+35.0)/(1.0 - exp(-(v+35.0)/10.0))

--- a/src/blox/stochastic.jl
+++ b/src/blox/stochastic.jl
@@ -17,8 +17,7 @@ mutable struct OUBlox <: NeuralMassBlox
     stochastic
     system
     function OUBlox(;name, namespace=nothing, μ=0.0, σ=1.0, τ=1.0)
-        p = paramscoping(μ=μ, τ=τ, σ=σ)
-        μ, τ, σ = p
+        p = @paramscoping μ τ σ
         sts = @variables x(t)=0.0 [output=true] jcn(t) [input=true]
         @brownian w
 

--- a/src/measurementmodels/fmri.jl
+++ b/src/measurementmodels/fmri.jl
@@ -71,8 +71,7 @@ struct BalloonModel <: ObserverBlox
         B = [0.04, 4, 25, 40.3, 0.4]
         k1 = 4.3*B[1]*B[4]*B[5]                         # coefficients in BOLD signal model
 
-        p = paramscoping(lnκ=lnκ, lnτ=lnτ, lnϵ=lnϵ)     # finally compile all parameters
-        lnκ, lnτ, lnϵ = p                               # assign the modified parameters
+        p = @paramscoping lnκ lnτ lnϵ     # finally compile all parameters
 
         sts = @variables s(t)=0.0 lnu(t)=0.0 lnν(t)=0.0 lnq(t)=0.0 bold(t)=0.0 [irreducible=true, output=true, description="measurement"] jcn(t) [input=true]
 

--- a/src/measurementmodels/lfp.jl
+++ b/src/measurementmodels/lfp.jl
@@ -5,8 +5,7 @@ struct LeadField <: ObserverBlox
     namespace
 
     function LeadField(;name, namespace=nothing, L=1.0)
-        p = paramscoping(L=L)
-        L, = p
+        p = @paramscoping L
 
         sts = @variables lfp(t)=0.0 [irreducible=true, output=true, description="measurement"] jcn(t)=1.0 [input=true]
 


### PR DESCRIPTION
The `paramscoping` function has the annoying property that you need to write the variable names multiple times, and unpack the param vector. Hence you get lots of code throughout Neuroblox that looks like
```julia
p = paramscoping(τ_E=τ_E, τ_I=τ_I, a_E=a_E, a_I=a_I, c_EE=c_EE, c_IE=c_IE, c_EI=c_EI, c_II=c_II, θ_E=θ_E, θ_I=θ_I, η=η)
τ_E, τ_I, a_E, a_I, c_EE, c_IE, c_EI, c_II, θ_E, θ_I, η = p
```
This new `@paramscoping` macro replaces that with
```julia
p = @paramscoping τ_E τ_I a_E a_I c_EE c_IE c_EI c_II θ_E θ_I η
```
Encountered this today because @gabrevaya encountered some **very** confusing behaviour because he didn't know that he had to use the 
```julia
τ_E, τ_I, a_E, a_I, c_EE, c_IE, c_EI, c_II, θ_E, θ_I, η = p
```
line after calling `paramscoping(τ_E=τ_E, τ_I=τ_I, a_E=a_E, a_I=a_I, c_EE=c_EE, c_IE=c_IE, c_EI=c_EI, c_II=c_II, θ_E=θ_E, θ_I=θ_I, η=η)`. 

I think this change is cleaner, and less error prone. 