### PR TITLE
add `name` field to all `StimulusBlox` for compatibility with GD

### DIFF
--- a/src/blox/DBS_sources.jl
+++ b/src/blox/DBS_sources.jl
@@ -1,13 +1,15 @@
 # Continuous square‑pulse DBS stimulus
 struct DBS <: StimulusBlox
-    system    :: ODESystem
-    namespace :: Union{Symbol,Nothing}
+    name        ::Symbol
+    system      ::ODESystem
+    namespace   ::Union{Symbol,Nothing}
 end
 
 # Burst DBS stimulus
 struct ProtocolDBS <: StimulusBlox
-    system    :: ODESystem
-    namespace :: Union{Symbol,Nothing}
+    name        ::Symbol
+    system      ::ODESystem
+    namespace   ::Union{Symbol,Nothing}
 end
 
 """
@@ -47,7 +49,7 @@ function DBS(;
     eqs = [u ~ stimulus(t)]
     sys = ODESystem(eqs, t, [u], stim_param; name=name)
 
-    return DBS(sys, namespace)
+    return DBS(name, sys, namespace)
 end
 
 """
@@ -88,7 +90,7 @@ function ProtocolDBS(;
     pre_block_time=200.0,
     inter_burst_time=200.0
     )
-
+    
     stim = BurstStimulus(frequency, amplitude, offset, start_time, pulse_width, smooth,
                          pulses_per_burst, bursts_per_block,
                          pre_block_time, inter_burst_time)
@@ -100,7 +102,7 @@ function ProtocolDBS(;
     eqs = [u ~ stimulus(t)]
     sys = ODESystem(eqs, t, [u], stim_param; name=name)
 
-    return ProtocolDBS(sys, namespace)
+    return ProtocolDBS(name, sys, namespace)
 end
 
 # ------------------------------------------------------------------------------------------

--- a/src/blox/sources.jl
+++ b/src/blox/sources.jl
@@ -1,6 +1,7 @@
 abstract type AbstractSpikeSource <: StimulusBlox end
 
 struct VoltageClampSource <: StimulusBlox
+    name
     namespace
     system
 
@@ -15,11 +16,12 @@ struct VoltageClampSource <: StimulusBlox
 
         sys = System(eqs, t, [V], []; name=name, discrete_events=cbs)
 
-        new(namespace, sys)
+        new(name, namespace, sys)
     end
 end
 
 struct ConstantInput <: StimulusBlox
+    name
     namespace
     system
 
@@ -29,7 +31,7 @@ struct ConstantInput <: StimulusBlox
         eqs = [u ~ I]
         sys = System(eqs, t, [u], [I]; name=name)
 
-        new(namespace, sys)
+        new(name, namespace, sys)
     end
 end
 
@@ -46,6 +48,7 @@ end
 @register_symbolic get_sampled_data(t, t_trial::Real, t_stims::AbstractVector, pixel_data::AbstractVector)
 
 mutable struct ImageStimulus <: StimulusBlox
+    const name
     const namespace
     const system
     const IMG # Matrix[pixels X stimuli]
@@ -93,7 +96,7 @@ mutable struct ImageStimulus <: StimulusBlox
 
         ps_namespaced = namespace_parameters(get_namespaced_sys(sys))
 
-        new(namespace, sys, S, ps_namespaced, category, t_stimulus, t_pause, N_pixels, N_stimuli, 1)
+        new(name, namespace, sys, S, ps_namespaced, category, t_stimulus, t_pause, N_pixels, N_stimuli, 1)
     end
 
     function ImageStimulus(file::String; name, namespace, t_stimulus, t_pause)


### PR DESCRIPTION
Add `name` field to all `StimulusBlox` for compatibility with GraphDynamics.